### PR TITLE
Only build master branch in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ env:
   - CLI_VERSION=latest
 
 branches:
-  except:
-    - deploy
-    - gh-pages
+  only:
+    - master
 
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,8 @@ environment:
   CLI_VERSION: latest
 
 branches:
-  except:
-    - deploy
-    - gh-pages
+  only:
+    - master
 
 install:
   - ps: mkdir -Force ".\.dotnetcli\" | Out-Null


### PR DESCRIPTION
Only build the ```master``` branch in AppVeyor and Travis CI.