### PR TITLE
Allow the Content-Type header in CORS

### DIFF
--- a/src/API/Options/ApiCorsOptions.cs
+++ b/src/API/Options/ApiCorsOptions.cs
@@ -14,6 +14,11 @@ namespace MartinCostello.Api.Options
         public string[] ExposedHeaders { get; set; }
 
         /// <summary>
+        /// Gets or sets the names of the allowed HTTP request headers.
+        /// </summary>
+        public string[] Headers { get; set; }
+
+        /// <summary>
         /// Gets or sets the allowed HTTP methods.
         /// </summary>
         public string[] Methods { get; set; }

--- a/src/API/Startup.cs
+++ b/src/API/Startup.cs
@@ -204,8 +204,17 @@ namespace MartinCostello.Api
                 {
                     builder
                         .WithExposedHeaders(siteOptions.Api.Cors.ExposedHeaders)
-                        .WithMethods(siteOptions.Api.Cors.Methods)
-                        .WithOrigins(siteOptions.Api.Cors.Origins);
+                        .WithHeaders(siteOptions.Api.Cors.Headers)
+                        .WithMethods(siteOptions.Api.Cors.Methods);
+
+                    if (HostingEnvironment.IsDevelopment())
+                    {
+                        builder.AllowAnyOrigin();
+                    }
+                    else
+                    {
+                        builder.WithOrigins(siteOptions.Api.Cors.Origins);
+                    }
                 });
         }
 

--- a/src/API/appsettings.json
+++ b/src/API/appsettings.json
@@ -14,6 +14,7 @@
     "Api": {
       "Cors": {
         "ExposedHeaders": [ "X-Request-Duration", "X-Request-Id" ],
+        "Headers": [ "Content-Type" ],
         "Methods": [ "GET", "POST" ],
         "Origins": [ "https://martincostello.com", "https://dev.martincostello.com", "https://staging.martincostello.com" ]
       },


### PR DESCRIPTION
  * Allow the ```Content-Type``` header to be set in CORS requests for ```POST``` resources (e.g. ```/tools/hash```).
  * Allow any origin for CORS in development.