### PR TITLE
Remove header to disable Azure request affinity

### DIFF
--- a/src/API/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/API/Middleware/CustomHttpHeadersMiddleware.cs
@@ -73,11 +73,6 @@ namespace MartinCostello.Api.Middleware
                     context.Response.Headers.Remove("Server");
                     context.Response.Headers.Remove("X-Powered-By");
 
-                    if (_isProduction)
-                    {
-                        context.Response.Headers.Add("Arr-Disable-Session-Affinity", bool.TrueString);
-                    }
-
                     context.Response.Headers.Add("Content-Security-Policy", _contentSecurityPolicy);
                     context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
                     context.Response.Headers.Add("X-Download-Options", "noopen");


### PR DESCRIPTION
Remove the custom HTTP response header used to disable Azure Request Routing affinity as this is now configurable in the App Service slots themselves.