### PR TITLE
Use fixed dotnet CLI version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 dist: trusty
 
 env:
-  - CLI_VERSION=latest
+  - CLI_VERSION=1.0.0-preview2-003121
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ install:
   - ps: '& .\.dotnetcli\install.ps1 -version "$env:CLI_VERSION" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
   - ps: npm install npm -g
-  - ps: npm cache clean --loglevel=error
   - ps: npm install -g bower --loglevel=error
   - ps: npm install -g gulp --loglevel=error
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
   - ps: '& .\.dotnetcli\install.ps1 -version "$env:CLI_VERSION" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
-  - ps: npm install npm -g
+  - ps: npm install npm@3.10.6 -g
   - ps: npm install -g bower --loglevel=error
   - ps: npm install -g gulp --loglevel=error
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ os: Visual Studio 2015
 version: 1.0.{build}
 
 environment:
-  CLI_VERSION: latest
+  CLI_VERSION: 1.0.0-preview2-003121
 
 branches:
   only:


### PR DESCRIPTION
Use a fixed version of the dotnet CLI (```1.0.0-preview2-003121```) instead of ```latest```, as sometimes this causes build failures.

Also remove the step to clear the npm package cache in AppVeyor.