### PR TITLE
Add CSP report URI

### DIFF
--- a/src/API/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/API/Extensions/IApplicationBuilderExtensions.cs
@@ -20,15 +20,17 @@ namespace MartinCostello.Api.Extensions
         /// <param name="value">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
         /// <param name="environment">The current hosting environment.</param>
         /// <param name="config">The current configuration.</param>
+        /// <param name="options">The current site configuration options.</param>
         /// <returns>
         /// The value specified by <paramref name="value"/>.
         /// </returns>
         public static IApplicationBuilder UseCustomHttpHeaders(
             this IApplicationBuilder value,
             IHostingEnvironment environment,
-            IConfiguration config)
+            IConfiguration config,
+            SiteOptions options)
         {
-            return value.UseMiddleware<CustomHttpHeadersMiddleware>(environment, config);
+            return value.UseMiddleware<CustomHttpHeadersMiddleware>(environment, config, options);
         }
 
         /// <summary>

--- a/src/API/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/API/Middleware/CustomHttpHeadersMiddleware.cs
@@ -130,7 +130,7 @@ namespace MartinCostello.Api.Middleware
         private static string BuildContentSecurityPolicy(bool isProduction, SiteOptions options)
         {
             const string BasePolicy = @"
-default-src 'self';
+default-src 'self' maxcdn.bootstrapcdn.com;
 script-src 'self' ajax.googleapis.com maxcdn.bootstrapcdn.com www.google-analytics.com 'unsafe-inline';
 style-src 'self' ajax.googleapis.com fonts.googleapis.com maxcdn.bootstrapcdn.com 'unsafe-inline';
 img-src 'self' online.swagger.io www.google-analytics.com;

--- a/src/API/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/API/Middleware/CustomHttpHeadersMiddleware.cs
@@ -11,6 +11,7 @@ namespace MartinCostello.Api.Middleware
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
+    using Options;
 
     /// <summary>
     /// A class representing middleware for adding custom HTTP response headers. This class cannot be inherited.
@@ -48,13 +49,18 @@ namespace MartinCostello.Api.Middleware
         /// <param name="next">The delegate for the next part of the pipeline.</param>
         /// <param name="environment">The current hosting environment.</param>
         /// <param name="config">The current configuration.</param>
-        public CustomHttpHeadersMiddleware(RequestDelegate next, IHostingEnvironment environment, IConfiguration config)
+        /// <param name="options">The current site configuration options.</param>
+        public CustomHttpHeadersMiddleware(
+            RequestDelegate next,
+            IHostingEnvironment environment,
+            IConfiguration config,
+            SiteOptions options)
         {
             _next = next;
             _isProduction = environment.IsProduction();
             _environmentName = _isProduction ? null : environment.EnvironmentName;
             _datacenter = config["Azure:Datacenter"] ?? "Local";
-            _contentSecurityPolicy = BuildContentSecurityPolicy(_isProduction);
+            _contentSecurityPolicy = BuildContentSecurityPolicy(_isProduction, options);
         }
 
         /// <summary>
@@ -117,10 +123,11 @@ namespace MartinCostello.Api.Middleware
         /// Builds the Content Security Policy to use for the website.
         /// </summary>
         /// <param name="isProduction">Whether the current environment is production.</param>
+        /// <param name="options">The current site configuration options.</param>
         /// <returns>
         /// A <see cref="string"/> containing the Content Security Policy to use.
         /// </returns>
-        private static string BuildContentSecurityPolicy(bool isProduction)
+        private static string BuildContentSecurityPolicy(bool isProduction, SiteOptions options)
         {
             const string BasePolicy = @"
 default-src 'self';
@@ -144,6 +151,11 @@ manifest-src 'self';";
             if (isProduction)
             {
                 builder.Append("upgrade-insecure-requests;");
+
+                if (options?.ExternalLinks?.Reports?.ContentSecurityPolicy != null)
+                {
+                    builder.Append($"report-uri {options.ExternalLinks.Reports.ContentSecurityPolicy};");
+                }
             }
 
             return builder.ToString();

--- a/src/API/Options/ExternalLinksOptions.cs
+++ b/src/API/Options/ExternalLinksOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Api.Options
+{
+    using System;
+
+    /// <summary>
+    /// A class representing the external link options for the site. This class cannot be inherited.
+    /// </summary>
+    public sealed class ExternalLinksOptions
+    {
+        /// <summary>
+        /// Gets or sets the URI of the blog.
+        /// </summary>
+        public Uri Blog { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI of the status website.
+        /// </summary>
+        public Uri Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the options for the URIs to use for reports.
+        /// </summary>
+        public ReportOptions Reports { get; set; }
+    }
+}

--- a/src/API/Options/ReportOptions.cs
+++ b/src/API/Options/ReportOptions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Api.Options
+{
+    using System;
+
+    /// <summary>
+    /// A class representing the options for reports. This class cannot be inherited.
+    /// </summary>
+    public sealed class ReportOptions
+    {
+        /// <summary>
+        /// Gets or sets the URI to use for <c>Content-Security-Policy</c>.
+        /// </summary>
+        public Uri ContentSecurityPolicy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI to use for <c>Content-Security-Policy-Report-Only</c>.
+        /// </summary>
+        public Uri ContentSecurityPolicyReportOnly { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI to use for <c>Public-Key-Pins</c>.
+        /// </summary>
+        public Uri PublicKeyPins { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI to use for <c>Public-Key-Pins-Report-Only</c>.
+        /// </summary>
+        public Uri PublicKeyPinsReportOnly { get; set; }
+    }
+}

--- a/src/API/Options/SiteOptions.cs
+++ b/src/API/Options/SiteOptions.cs
@@ -19,6 +19,11 @@ namespace MartinCostello.Api.Options
         public ApiOptions Api { get; set; }
 
         /// <summary>
+        /// Gets or sets the external link options for the site.
+        /// </summary>
+        public ExternalLinksOptions ExternalLinks { get; set; }
+
+        /// <summary>
         /// Gets or sets the metadata options for the site.
         /// </summary>
         public MetadataOptions Metadata { get; set; }

--- a/src/API/Startup.cs
+++ b/src/API/Startup.cs
@@ -80,7 +80,7 @@ namespace MartinCostello.Api
         {
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
 
-            app.UseCustomHttpHeaders(environment, Configuration);
+            app.UseCustomHttpHeaders(environment, Configuration, ServiceProvider.GetRequiredService<SiteOptions>());
             app.UseMiddleware<CustomIpRateLimitMiddleware>();
 
             if (environment.IsDevelopment())

--- a/src/API/Views/Home/Index.cshtml
+++ b/src/API/Views/Home/Index.cshtml
@@ -23,11 +23,11 @@
     <div class="col-md-6">
         <h2>Website</h2>
         <p>My main website.</p>
-        <p><a id="link-website" href="https://martincostello.com/" class="btn btn-default" target="_blank">Visit website »</a></p>
+        <p><a id="link-website" href="@Options.Metadata.Author.Website" class="btn btn-default" target="_blank">Visit website »</a></p>
     </div>
     <div class="col-md-6">
         <h2>Blog</h2>
         <p>I occasionally blog about topics related to .NET development.</p>
-        <p><a id="link-blog" href="https://blog.martincostello.com/" class="btn btn-default" target="_blank">Visit blog »</a></p>
+        <p><a id="link-blog" href="@Options.ExternalLinks.Blog.AbsoluteUri" class="btn btn-default" target="_blank">Visit blog »</a></p>
     </div>
 </div>

--- a/src/API/Views/Shared/_Layout.cshtml
+++ b/src/API/Views/Shared/_Layout.cshtml
@@ -50,8 +50,8 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
                     <li><a id="link-docs" href="/@Options.Api.Documentation.Location">Documentation</a></li>
-                    <li><a id="link-blog" href="https://blog.martincostello.com/" target="_blank">Blog</a></li>
-                    <li><a id="link-about" href="https://martincostello.com/home/about/" target="_blank">About</a></li>
+                    <li><a id="link-blog" href="@Options.ExternalLinks.Blog.AbsoluteUri" target="_blank">Blog</a></li>
+                    <li><a id="link-about" href="@(new Uri(new Uri(Options.Metadata.Author.Website), "home/about/"))" target="_blank">About</a></li>
                 </ul>
             </div>
         </div>
@@ -60,7 +60,7 @@
         @RenderBody()
         <hr />
         <footer>
-            <p>&copy; @Options.Metadata.Author.Name @DateTimeOffset.UtcNow.Year | <a href="http://status.martincostello.com/" target="_blank" title="View site uptime information">Site Status &amp; Uptime</a> | Built from <a href="@Options.Metadata.Repository/commit/@GitMetadata.Commit" title="View commit @GitMetadata.Commit on GitHub">@string.Join(string.Empty, GitMetadata.Commit.Take(7))</a> on <a href="@Options.Metadata.Repository/tree/@GitMetadata.Branch" title="View branch @GitMetadata.Branch on GitHub">@GitMetadata.Branch</a></p>
+            <p>&copy; @Options.Metadata.Author.Name @DateTimeOffset.UtcNow.Year | <a href="@Options.ExternalLinks.Status.AbsoluteUri" target="_blank" title="View site uptime information">Site Status &amp; Uptime</a> | Built from <a href="@Options.Metadata.Repository/commit/@GitMetadata.Commit" title="View commit @GitMetadata.Commit on GitHub">@string.Join(string.Empty, GitMetadata.Commit.Take(7))</a> on <a href="@Options.Metadata.Repository/tree/@GitMetadata.Branch" title="View branch @GitMetadata.Branch on GitHub">@GitMetadata.Branch</a></p>
         </footer>
     </div><environment names="Development">
     <script src="~/lib/jquery/dist/jquery.js"></script>

--- a/src/API/appsettings.json
+++ b/src/API/appsettings.json
@@ -44,6 +44,16 @@
         "Url": "https://github.com/martincostello/api/blob/master/LICENSE"
       }
     },
+    "ExternalLinks": {
+      "Blog": "https://blog.martincostello.com/",
+      "Status": "http://status.martincostello.com/",
+      "Reports": {
+        "ContentSecurityPolicy": "https://martincostello.report-uri.io/r/default/csp/enforce",
+        "ContentSecurityPolicyReportOnly": "https://martincostello.report-uri.io/r/default/csp/reportOnly",
+        "PublicKeyPins": "https://martincostello.report-uri.io/r/default/hpkp/enforce",
+        "PublicKeyPinsReportOnly": "https://martincostello.report-uri.io/r/default/hpkp/reportOnly"
+      }
+    },
     "Metadata": {
       "Author": {
         "Email": "martin@martincostello.com",


### PR DESCRIPTION
Add ```report-uri``` to the content security policy in production.

Also:
  1. configures report URIs for ```Content-Security-Policy-Report-Only```, ```Public-Key-Pins``` and ```Public-Key-Pins-Report-Only```;
  1. configures links to other domains instead of hard-coding them;
  1. fixes CSP warnings that only occur in Firefox.