### PR TITLE
Add report header for public key pins

### DIFF
--- a/src/API/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/API/Middleware/CustomHttpHeadersMiddleware.cs
@@ -24,7 +24,7 @@ namespace MartinCostello.Api.Middleware
         private readonly RequestDelegate _next;
 
         /// <summary>
-        /// The current Content Security Policy. This field is read-only.
+        /// The current <c>Content-Security-Policy</c> HTTP response header value. This field is read-only.
         /// </summary>
         private readonly string _contentSecurityPolicy;
 
@@ -32,6 +32,11 @@ namespace MartinCostello.Api.Middleware
         /// The name of the current hosting environment. This field is read-only.
         /// </summary>
         private readonly string _environmentName;
+
+        /// <summary>
+        /// The current <c>Public-Key-Pins</c> HTTP response header value. This field is read-only.
+        /// </summary>
+        private readonly string _publicKeyPins;
 
         /// <summary>
         /// The current datacenter name. This field is read-only.
@@ -61,6 +66,7 @@ namespace MartinCostello.Api.Middleware
             _environmentName = _isProduction ? null : environment.EnvironmentName;
             _datacenter = config["Azure:Datacenter"] ?? "Local";
             _contentSecurityPolicy = BuildContentSecurityPolicy(_isProduction, options);
+            _publicKeyPins = BuildPublicKeyPins(options);
         }
 
         /// <summary>
@@ -88,6 +94,11 @@ namespace MartinCostello.Api.Middleware
                     if (context.Request.IsHttps)
                     {
                         context.Response.Headers.Add("Strict-Transport-Security", "max-age=31536000");
+
+                        if (!string.IsNullOrWhiteSpace(_publicKeyPins))
+                        {
+                            context.Response.Headers.Add("Public-Key-Pins-Report-Only", _publicKeyPins);
+                        }
                     }
 
                     context.Response.Headers.Add("X-Datacenter", _datacenter);
@@ -155,6 +166,40 @@ manifest-src 'self';";
                 if (options?.ExternalLinks?.Reports?.ContentSecurityPolicy != null)
                 {
                     builder.Append($"report-uri {options.ExternalLinks.Reports.ContentSecurityPolicy};");
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Builds the value to use for the <c>Public-Key-Pins</c> HTTP response header.
+        /// </summary>
+        /// <param name="options">The current site configuration options.</param>
+        /// <returns>
+        /// A <see cref="string"/> containing the <c>Public-Key-Pins</c> value to use.
+        /// </returns>
+        private static string BuildPublicKeyPins(SiteOptions options)
+        {
+            var builder = new StringBuilder();
+
+            if (options?.PublicKeyPins?.Sha256Hashes?.Length > 0)
+            {
+                builder.AppendFormat("max-age={0};", (int)options.PublicKeyPins.MaxAge.TotalSeconds);
+
+                foreach (var hash in options.PublicKeyPins.Sha256Hashes)
+                {
+                    builder.Append($@" pin-sha256=""{hash}"";");
+                }
+
+                if (options.PublicKeyPins.IncludeSubdomains)
+                {
+                    builder.Append(" includeSubDomains;");
+                }
+
+                if (options?.ExternalLinks?.Reports?.PublicKeyPinsReportOnly != null)
+                {
+                    builder.Append($" report-uri=\"{options.ExternalLinks.Reports.PublicKeyPinsReportOnly}\";");
                 }
             }
 

--- a/src/API/Options/PublicKeyPinsOptions.cs
+++ b/src/API/Options/PublicKeyPinsOptions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Api.Options
+{
+    using System;
+
+    /// <summary>
+    /// A class representing the options to use for the <c>Public-Key-Pins</c>
+    /// HTTP response header. This class cannot be inherited.
+    /// </summary>
+    public sealed class PublicKeyPinsOptions
+    {
+        /// <summary>
+        /// Gets or sets the maximum period of time to cache pins for.
+        /// </summary>
+        public TimeSpan MaxAge { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include subdomains.
+        /// </summary>
+        public bool IncludeSubdomains { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SHA-256 hashes of the certificates to pin.
+        /// </summary>
+        public string[] Sha256Hashes { get; set; }
+    }
+}

--- a/src/API/Options/SiteOptions.cs
+++ b/src/API/Options/SiteOptions.cs
@@ -27,5 +27,10 @@ namespace MartinCostello.Api.Options
         /// Gets or sets the metadata options for the site.
         /// </summary>
         public MetadataOptions Metadata { get; set; }
+
+        /// <summary>
+        /// Gets or sets the options for the public key pins to use.
+        /// </summary>
+        public PublicKeyPinsOptions PublicKeyPins { get; set; }
     }
 }

--- a/src/API/appsettings.json
+++ b/src/API/appsettings.json
@@ -71,6 +71,17 @@
       "Repository": "https://github.com/martincostello/api",
       "Robots": "INDEX",
       "Type": "website"
+    },
+    "PublicKeyPins": {
+      "MaxAge": "60.00:00:00",
+      "IncludeSubdomains": false,
+      "Sha256Hashes": [
+        "wvMoN/75fGqUXeGDMNIe704oXvDghZhTNYhtQ7td+aY=",
+        "klO23nT2ehFDXCfx3eHTDRESMz3asj1muO+4aIdjiuY=",
+        "lCppFqbkrlJ3EcVFAkeip0+44VaoJUymbnOaEUk7tEU=",
+        "iie1VXtL7HzAMF+/PVPR9xzT80kQxdZeJ+zduCB3uj0=",
+        "JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg="
+      ]
     }
   }
 }


### PR DESCRIPTION
Add the ```Public-Key-Pins-Report-Only``` HTTP response header to investigate use of public key pinning for HTTPS/TLS.

SHA-256 values generated from [here](https://report-uri.io/home/pkp_hash/).