### PR TITLE
Disable rate limiting

### DIFF
--- a/src/API/Startup.cs
+++ b/src/API/Startup.cs
@@ -81,7 +81,8 @@ namespace MartinCostello.Api
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
 
             app.UseCustomHttpHeaders(environment, Configuration, ServiceProvider.GetRequiredService<SiteOptions>());
-            app.UseMiddleware<CustomIpRateLimitMiddleware>();
+
+            ////app.UseMiddleware<CustomIpRateLimitMiddleware>();
 
             if (environment.IsDevelopment())
             {
@@ -129,8 +130,9 @@ namespace MartinCostello.Api
         {
             services.AddOptions();
             services.Configure<SiteOptions>(Configuration.GetSection("Site"));
-            services.Configure<IpRateLimitOptions>(Configuration.GetSection("IpRateLimiting"));
-            services.Configure<IpRateLimitPolicies>(Configuration.GetSection("IpRateLimitPolicies"));
+
+            ////services.Configure<IpRateLimitOptions>(Configuration.GetSection("IpRateLimiting"));
+            ////services.Configure<IpRateLimitPolicies>(Configuration.GetSection("IpRateLimitPolicies"));
 
             services.AddAntiforgery(
                 (p) =>


### PR DESCRIPTION
Disable API rate limiting added by #27 as it is possibly the culprit of the outage from the last deployment.