### PR TITLE
Fix jumbotron

### DIFF
--- a/src/API/Assets/Scripts/js/analytics.js
+++ b/src/API/Assets/Scripts/js/analytics.js
@@ -1,4 +1,7 @@
-﻿(function () {
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+(function () {
     var trackingId = $("meta[name='google-analytics']").attr("content");
     if (trackingId !== "") {
         (function (i, s, o, g, r, a, m) {

--- a/src/API/Assets/Scripts/js/site.js
+++ b/src/API/Assets/Scripts/js/site.js
@@ -1,4 +1,7 @@
-﻿martinCostello = {
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+martinCostello = {
     api: {
     }
 };

--- a/src/API/Assets/Scripts/js/site.spec.js
+++ b/src/API/Assets/Scripts/js/site.spec.js
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+describe("Given the namespaces are defined", function () {
+
+    it("then martinCostello is not null", function () {
+        expect(martinCostello).not.toBeNull();
+    });
+
+    it("then martinCostello.api is not null", function () {
+        expect(martinCostello.api).not.toBeNull();
+    });
+});

--- a/src/API/Startup.cs
+++ b/src/API/Startup.cs
@@ -19,6 +19,7 @@ namespace MartinCostello.Api
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
+    using Microsoft.Net.Http.Headers;
     using Middleware;
     using Newtonsoft.Json;
     using NodaTime;
@@ -96,7 +97,18 @@ namespace MartinCostello.Api
                    .UseStatusCodePagesWithReExecute("/error", "?id={0}");
             }
 
-            app.UseStaticFiles();
+            app.UseStaticFiles(
+                new StaticFileOptions()
+                {
+                    OnPrepareResponse = (context) =>
+                    {
+                        var headers = context.Context.Response.GetTypedHeaders();
+                        headers.CacheControl = new CacheControlHeaderValue()
+                        {
+                            MaxAge = TimeSpan.FromDays(7)
+                        };
+                    }
+                });
 
             app.UseForwardedHeaders(
                 new ForwardedHeadersOptions()

--- a/src/API/Views/Shared/_Layout.cshtml
+++ b/src/API/Views/Shared/_Layout.cshtml
@@ -62,20 +62,23 @@
         <footer>
             <p>&copy; @Options.Metadata.Author.Name @DateTimeOffset.UtcNow.Year | <a href="@Options.ExternalLinks.Status.AbsoluteUri" target="_blank" title="View site uptime information">Site Status &amp; Uptime</a> | Built from <a href="@Options.Metadata.Repository/commit/@GitMetadata.Commit" title="View commit @GitMetadata.Commit on GitHub">@string.Join(string.Empty, GitMetadata.Commit.Take(7))</a> on <a href="@Options.Metadata.Repository/tree/@GitMetadata.Branch" title="View branch @GitMetadata.Branch on GitHub">@GitMetadata.Branch</a></p>
         </footer>
-    </div><environment names="Development">
+    </div>
+    <environment names="Development">
     <script src="~/lib/jquery/dist/jquery.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
     <script src="~/assets/js/site.js" asp-append-version="true"></script>
-    </environment><environment names="Staging,Production">
+    </environment>
+    <environment names="Staging,Production">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/@BowerVersions["jquery"]/jquery.min.js" integrity="sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo=" crossorigin="anonymous"
             asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
             asp-fallback-test="window.jQuery">
     </script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/@BowerVersions["bootstrap"]/js/bootstrap.min.js" integrity="sha256-KXn5puMvxCw+dAYznun+drMdG1IFl3agK0p/pqT9KAo=" crossorigin="anonymous"
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/@BowerVersions["bootstrap"]/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"
             asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
             asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal">
     </script>
-    <script src="~/assets/js/site.min.js" asp-append-version="true"></script></environment>
+    <script src="~/assets/js/site.min.js" asp-append-version="true"></script>
+    </environment>
     @RenderSection("scripts", required: false)
 </body>
 <!--

--- a/src/API/Views/Shared/_Links.cshtml
+++ b/src/API/Views/Shared/_Links.cshtml
@@ -18,11 +18,6 @@
     <link rel="icon" type="image/png" href="@Url.Content("~/favicon-96x96.png")" sizes="96x96" asp-append-version="true" />
     <link rel="icon" type="image/png" href="@Url.Content("~/favicon-16x16.png")" sizes="16x16" asp-append-version="true" />
 <environment names="Development">
-    <link rel="prefetch" href="~/lib/bootstrap/dist/css/bootstrap.css" asp-append-version="true" />
-    <link rel="preload" as="style" href="~/lib/bootstrap/dist/css/bootstrap.css" asp-append-version="true" />
-    <link rel="preload" as="script" href="~/lib/bootstrap/dist/js/bootstrap.js" asp-append-version="true" />
-    <link rel="preload" as="script" href="~/lib/jquery/dist/jquery.js" asp-append-version="true" />
-    <link rel="preload" as="script" href="~/assets/js/site.js" asp-append-version="true" />
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" asp-append-version="true" />
 </environment>
 <environment names="Staging,Production">
@@ -36,31 +31,18 @@
     <link rel="preconnect" href="//fonts.gstatic.com" />
     <link rel="preconnect" href="//maxcdn.bootstrapcdn.com" />
     <link rel="preconnect" href="//www.google-analytics.com" />
-    <link rel="prefetch" href="https://maxcdn.bootstrapcdn.com/bootstrap/@BowerVersions["bootstrap"]/css/bootstrap.min.css" />
-    <link rel="preload" as="style" href="https://maxcdn.bootstrapcdn.com/bootstrap/@BowerVersions["bootstrap"]/css/bootstrap.min.css" />
-    <link rel="preload" as="script" href="https://maxcdn.bootstrapcdn.com/bootstrap/@BowerVersions["bootstrap"]/js/bootstrap.min.js" />
-    <link rel="preload" as="script" href="https://ajax.googleapis.com/ajax/libs/jquery/@BowerVersions["jquery"]/jquery.min.js" />
-    <link rel="preload" as="script" href="~/assets/js/site.min.js" asp-append-version="true" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/@BowerVersions["bootstrap"]/css/bootstrap.min.css" integrity="sha256-7s5uDGW3AHqw6xtJmNNtr+OBRJUlgkNJEo78P4b0yRw=" crossorigin="anonymous"
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/@BowerVersions["bootstrap"]/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous"
           asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
           asp-fallback-test-class="sr-only"
           asp-fallback-test-property="position"
           asp-fallback-test-value="absolute" />
     <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" />
 </environment>
-    <link rel="prefetch" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" />
-    <link rel="preload" as="style" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" integrity="sha256-Av2lUNJFz7FqxLquvIFyxyCQA/VHUFna3onVy+5jUBM=" crossorigin="anonymous" />
-    <link rel="prefetch" href="//maxcdn.bootstrapcdn.com/font-awesome/@BowerVersions["font-awesome"]/css/font-awesome.min.css" />
-    <link rel="preload" as="style" href="//maxcdn.bootstrapcdn.com/font-awesome/@BowerVersions["font-awesome"]/css/font-awesome.min.css" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/@BowerVersions["bootstrap"]/flatly/bootstrap.min.css" integrity="sha384-+ENW/yibaokMnme+vBLnHMphUYxHs34h9lpdbSLuAwGkOKFRl4C34WkjazBtb7eT" crossorigin="anonymous" />
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/@BowerVersions["font-awesome"]/css/font-awesome.min.css" integrity="sha256-AIodEDkC8V/bHBkfyxzolUMw57jeQ9CauwhVW6YJ9CA=" crossorigin="anonymous" />
 <environment names="Development">
-    <link rel="prefetch" href="~/assets/css/site.css" asp-append-version="true" />
-    <link rel="preload" as="style" href="~/assets/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" />
 </environment>
 <environment names="Staging,Production">
-    <link rel="prefetch" href="~/assets/css/site.min.css" asp-append-version="true" />
-    <link rel="preload" as="style" href="~/assets/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/assets/css/site.min.css" asp-append-version="true" />
 </environment>

--- a/src/API/bower.json
+++ b/src/API/bower.json
@@ -2,7 +2,7 @@
   "name": "api.martincostello.com",
   "private": true,
   "dependencies": {
-    "bootstrap": "3.3.6",
+    "bootstrap": "3.3.7",
     "font-awesome": "4.6.3",
     "jquery": "2.2.3"
   }

--- a/src/API/gulpfile.js
+++ b/src/API/gulpfile.js
@@ -25,7 +25,7 @@ var paths = {
     jsDest: webroot + "js",
     minJs: webroot + "js/**/*.min.js",
     minJsDest: webroot + "js/site.min.js",
-    testsJs: "js/**/*.spec.js",
+    testsJs: scripts + "js/**/*.spec.js",
     css: styles + "css/**/*.css",
     minCssDest: webroot + "css/**/site.min.css",
     concatJsDest: webroot + "js/site.js",

--- a/src/API/gulpfile.js
+++ b/src/API/gulpfile.js
@@ -9,6 +9,7 @@ var gulp = require("gulp"),
     csslint = require("gulp-csslint"),
     jasmine = require("gulp-jasmine"),
     jshint = require("gulp-jshint"),
+    karmaServer = require("karma").Server,
     less = require("gulp-less"),
     lesshint = require("gulp-lesshint"),
     rename = require("gulp-rename"),
@@ -118,11 +119,21 @@ gulp.task("min:css", ["css"], function () {
 
 gulp.task("min", ["min:js", "min:css"]);
 
-gulp.task("test:js", function () {
-    return gulp.src(paths.testsJs)
-      .pipe(jasmine());
+gulp.task("test:js:karma", function (done) {
+    new karmaServer({
+        configFile: __dirname + "/karma.conf.js",
+        singleRun: true
+    }, done).start();
 });
 
+gulp.task("test:js:chrome", function (done) {
+    new karmaServer({
+        configFile: __dirname + "/karma.conf.js",
+        browsers: ["Chrome"]
+    }, done).start();
+});
+
+gulp.task("test:js", ["test:js:karma"]);
 gulp.task("test", ["test:js"]);
 
 gulp.task("build", ["lint", "min"]);

--- a/src/API/karma.conf.js
+++ b/src/API/karma.conf.js
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+module.exports = function (config) {
+    config.set({
+
+        autoWatch: false,
+        concurrency: Infinity,
+
+        browsers: ["PhantomJS"],
+        frameworks: ["jasmine"],
+
+        files: [
+            "wwwroot/lib/**/dist/*.js",
+            "Assets/Scripts/js/site.js",
+            "Assets/Scripts/**/*.spec.js"
+        ],
+
+        htmlDetailed: {
+            splitResults: false
+        },
+
+        plugins: [
+            "karma-appveyor-reporter",
+            "karma-chrome-launcher",
+            "karma-html-detailed-reporter",
+            "karma-jasmine",
+            "karma-phantomjs-launcher"
+        ],
+
+        reporters: [
+            "progress",
+            "appveyor"
+        ]
+    })
+}

--- a/src/API/package.json
+++ b/src/API/package.json
@@ -17,6 +17,13 @@
     "gulp-sass": "2.3.1",
     "gulp-sass-lint": "1.1.1",
     "gulp-uglify": "1.2.0",
-    "jshint": "2.9.2"
+    "jshint": "2.9.2",
+    "karma": "1.2.0",
+    "karma-appveyor-reporter": "0.3.0",
+    "karma-chrome-launcher": "1.0.1",
+    "karma-html-detailed-reporter": "1.1.8",
+    "karma-jasmine": "1.0.2",
+    "karma-phantomjs-launcher": "1.0.1",
+    "phantomjs": "2.1.7"
   }
 }


### PR DESCRIPTION
Fix #33 by adding a Jasmine test to stop silent failure of Gulp in VSTS build which caused static assets to not be produced in the MSDeploy package.

Also update to Bootstrap 3.3.7, enable static file caching and use Karma to run Jasmine tests instead of Gulp.