### PR TITLE
Fix JavaScript concatenation

### DIFF
--- a/src/API/gulpfile.js
+++ b/src/API/gulpfile.js
@@ -95,7 +95,7 @@ gulp.task("lint:sass", function () {
 gulp.task("lint", ["lint:js", "lint:less", "lint:sass", "lint:css"]);
 
 gulp.task("min:js", function () {
-    return gulp.src([paths.js, "!" + paths.minJs, "!" + paths.concatJsDest])
+    return gulp.src([paths.js, "!" + paths.minJs, "!" + paths.concatJsDest, "!" + paths.testsJs])
         .pipe(concat(paths.concatJsDest))
         .pipe(gulp.dest("."))
         .pipe(uglify())


### PR DESCRIPTION
Fix JavaScript concatenation broken by beb40875dc637cd179798504acf7d686951f4d4d by excluding Jasmine specs from the minified JavaScript.