### PR TITLE
Fix incorrect property name in _Scripts

### DIFF
--- a/src/API/Views/Shared/_Scripts.cshtml
+++ b/src/API/Views/Shared/_Scripts.cshtml
@@ -14,7 +14,7 @@
             asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
             asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal">
     </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/@Model["moment"]/moment.min.js" integrity="sha384-7pfELK0arQ3VANqV4kiPWPh5wOsrfitjFGF/NdyHXUJ3JJPy/rNhasPtdkaNKhul" crossorigin="anonymous"
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/@BowerVersions["moment"]/moment.min.js" integrity="sha384-7pfELK0arQ3VANqV4kiPWPh5wOsrfitjFGF/NdyHXUJ3JJPy/rNhasPtdkaNKhul" crossorigin="anonymous"
             asp-fallback-src="~/lib/moment/min/moment.min.js"
             asp-fallback-test="window.moment">
     </script>


### PR DESCRIPTION
Fix incorrect property name in _Scripts causing an exception rendering the homepage caused by #40.