### PR TITLE
Improve Travis CI build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: csharp
-
 sudo: required
 dist: trusty
 
@@ -21,9 +19,6 @@ addons:
     - libicu-dev
     - libssl-dev
     - libunwind8
-
-mono:
-  - latest
 
 install:
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"


### PR DESCRIPTION
Improve build time for Travis CI by not using an image that installs Mono.