### PR TITLE
Fix VSTS build branch name

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -75,8 +75,13 @@ function DotNetPublish { param([string]$Project)
 
 if ($PatchVersion -eq $true) {
 
+    $gitBranch = $env:BUILD_SOURCEBRANCHNAME
+
+    if ([string]::IsNullOrEmpty($gitBranch)) {
+        $gitBranch = (git rev-parse --abbrev-ref HEAD | Out-String).Trim()
+    }
+
     $gitRevision = (git rev-parse HEAD | Out-String).Trim()
-    $gitBranch   = (git rev-parse --abbrev-ref HEAD | Out-String).Trim()
     $timestamp   = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssK")
 
     $assemblyVersion = Get-Content ".\AssemblyVersion.cs" -Raw


### PR DESCRIPTION
Fix the branch name in the assembly metadata being incorrect when compiled in VSTS.
Resolves #45.