### PR TITLE
Fix publishing and improve build script

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -18,22 +18,40 @@ if ($OutputPath -eq "") {
     $OutputPath = "$(Convert-Path "$PSScriptRoot")\artifacts"
 }
 
-$env:DOTNET_INSTALL_DIR = "$(Convert-Path "$PSScriptRoot")\.dotnetcli"
-
 if ($env:CI -ne $null -Or $env:TF_BUILD -ne $null) {
     $RestorePackages = $true
     $PatchVersion = $true
 }
 
-if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
-    mkdir $env:DOTNET_INSTALL_DIR | Out-Null
-    $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
-    Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
-    & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
+$installDotNetSdk = $false;
+
+if ((Get-Command "dotnet.exe" -ErrorAction SilentlyContinue) -eq $null)  {
+    Write-Host "The .NET Core SDK is not installed."
+    $installDotNetSdk = $true
+}
+else {
+    $installedDotNetVersion = (dotnet --version | Out-String).Trim()
+    if ($installedDotNetVersion -ne $dotnetVersion) {
+        Write-Host "The required version of the .NET Core SDK is not installed. Expected $dotnetVersion but $installedDotNetVersion was found."
+        $installDotNetSdk = $true
+    }
 }
 
-$env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
-$dotnet   = "$env:DOTNET_INSTALL_DIR\dotnet"
+if ($installDotNetSdk -eq $true) {
+    $env:DOTNET_INSTALL_DIR = "$(Convert-Path "$PSScriptRoot")\.dotnetcli"
+
+    if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
+        mkdir $env:DOTNET_INSTALL_DIR | Out-Null
+        $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
+        Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
+        & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
+    }
+
+    $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
+    $dotnet   = "$env:DOTNET_INSTALL_DIR\dotnet"
+} else {
+    $dotnet   = "dotnet"
+}
 
 function DotNetRestore {
     param([string]$Project)

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -52,4 +52,9 @@
     <Exec Command="bower install --loglevel=error" />
     <Exec Command="gulp publish" />
   </Target>
+  <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths" DependsOnTargets="PrepareForPublish">
+    <ItemGroup>
+      <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
  * Fix generated content from gulp not being included in the publish package.
  * Only download the .NET Core SDK locally if the right version is not already installed in ```Build.ps1```.