### PR TITLE
Update to .NET Core 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,18 @@ dist: trusty
 
 env:
   global:
-    - CLI_VERSION=1.0.4
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
     - NUGET_XMLDOC_MODE=skip
 
 branches:
   only:
     - master
+
+cache:
+  directories:
+    - /home/travis/.npm
+    - /home/travis/.nuget/packages
+    - src/API/node_modules
 
 addons:
   apt:
@@ -21,12 +26,9 @@ addons:
     - libunwind8
 
 install:
-  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
-  - curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
-  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
-  - npm install -g bower
-  - npm install -g gulp
-  - dotnet --info
+  - npm install -g npm@4.5.0
+  - npm install -g bower@1.8.0
+  - npm install -g gulp@3.9.1
 
 script:
-  - ./build.sh
+  - ./build.sh --restore-packages

--- a/API.Common.props
+++ b/API.Common.props
@@ -1,12 +1,12 @@
-﻿<Project>
+<Project>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <PropertyGroup>
     <Authors>Martin Costello</Authors>
     <CodeAnalysisRuleSet>../../API.ruleset</CodeAnalysisRuleSet>
-    <Company>https://github.com/martincostello/website</Company>
-    <Copyright>Martin Costello (c) 2016-2017</Copyright>
+    <Company>https://github.com/martincostello/api</Company>
+    <Copyright>Martin Costello (c) 2016-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <DefineConstants>$(DefineConstants)</DefineConstants>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -20,7 +20,8 @@
     <PackageTags></PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>

--- a/API.Common.props
+++ b/API.Common.props
@@ -24,4 +24,7 @@
     <VersionSuffix></VersionSuffix>
     <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(CI)' != '' or '$(TF_BUILD)' != '' ">
+    <InstallWebPackages>true</InstallWebPackages>
+  </PropertyGroup>
 </Project>

--- a/API.Common.props
+++ b/API.Common.props
@@ -20,10 +20,10 @@
     <PackageTags></PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
-    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(CI)' != '' or '$(TF_BUILD)' != '' ">
     <InstallWebPackages>true</InstallWebPackages>

--- a/API.sln
+++ b/API.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FBF500AA-F3F9-457B-818B-05D53AE9C901}"
 EndProject
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
 		.travis.yml = .travis.yml
+		API.Common.props = API.Common.props
 		API.ruleset = API.ruleset
 		appveyor.yml = appveyor.yml
 		AssemblyVersion.cs = AssemblyVersion.cs
@@ -21,11 +22,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		stylecop.json = stylecop.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "API", "src\API\API.csproj", "{1CCAD84E-2E62-43AB-8158-45DD93249875}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "API", "src\API\API.csproj", "{1CCAD84E-2E62-43AB-8158-45DD93249875}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E50CFF7D-C9F2-44ED-B596-593F614B5ED6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "API.Tests", "tests\API.Tests\API.Tests.csproj", "{67917CF1-BCF9-4808-8965-FD1A7334C3BC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "API.Tests", "tests\API.Tests\API.Tests.csproj", "{67917CF1-BCF9-4808-8965-FD1A7334C3BC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -48,5 +49,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{1CCAD84E-2E62-43AB-8158-45DD93249875} = {FBF500AA-F3F9-457B-818B-05D53AE9C901}
 		{67917CF1-BCF9-4808-8965-FD1A7334C3BC} = {E50CFF7D-C9F2-44ED-B596-593F614B5ED6}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DBF2FAD3-39E4-4077-AE0B-5C0AE27673B8}
 	EndGlobalSection
 EndGlobal

--- a/Build.ps1
+++ b/Build.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference = "Stop"
 
 $solutionPath = Split-Path $MyInvocation.MyCommand.Definition
 $solutionFile = Join-Path $solutionPath "API.sln"
-$dotnetVersion = "2.0.0-preview2-006497"
+$dotnetVersion = "2.0.0"
 
 if ($OutputPath -eq "") {
     $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"

--- a/Build.ps1
+++ b/Build.ps1
@@ -1,21 +1,20 @@
 param(
-    [Parameter(Mandatory=$false)][bool]   $RestorePackages  = $false,
-    [Parameter(Mandatory=$false)][string] $Configuration    = "Release",
-    [Parameter(Mandatory=$false)][string] $VersionSuffix    = "",
-    [Parameter(Mandatory=$false)][string] $OutputPath       = "",
-    [Parameter(Mandatory=$false)][bool]   $PatchVersion     = $false,
-    [Parameter(Mandatory=$false)][bool]   $RunTests         = $true,
-    [Parameter(Mandatory=$false)][bool]   $PublishWebsite   = $true
+    [Parameter(Mandatory = $false)][switch] $RestorePackages,
+    [Parameter(Mandatory = $false)][string] $Configuration = "Release",
+    [Parameter(Mandatory = $false)][string] $VersionSuffix = "",
+    [Parameter(Mandatory = $false)][string] $OutputPath = "",
+    [Parameter(Mandatory = $false)][switch] $PatchVersion,
+    [Parameter(Mandatory = $false)][switch] $SkipTests
 )
 
 $ErrorActionPreference = "Stop"
 
-$solutionPath  = Split-Path $MyInvocation.MyCommand.Definition
-$framework     = "netcoreapp1.1"
-$dotnetVersion = "1.0.4"
+$solutionPath = Split-Path $MyInvocation.MyCommand.Definition
+$solutionFile = Join-Path $solutionPath "API.sln"
+$dotnetVersion = "2.0.0-preview1-005977"
 
 if ($OutputPath -eq "") {
-    $OutputPath = "$(Convert-Path "$PSScriptRoot")\artifacts"
+    $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"
 }
 
 if ($env:CI -ne $null -Or $env:TF_BUILD -ne $null) {
@@ -25,7 +24,7 @@ if ($env:CI -ne $null -Or $env:TF_BUILD -ne $null) {
 
 $installDotNetSdk = $false;
 
-if ((Get-Command "dotnet.exe" -ErrorAction SilentlyContinue) -eq $null)  {
+if (((Get-Command "dotnet.exe" -ErrorAction SilentlyContinue) -eq $null) -and ((Get-Command "dotnet" -ErrorAction SilentlyContinue) -eq $null)) {
     Write-Host "The .NET Core SDK is not installed."
     $installDotNetSdk = $true
 }
@@ -38,19 +37,21 @@ else {
 }
 
 if ($installDotNetSdk -eq $true) {
-    $env:DOTNET_INSTALL_DIR = "$(Convert-Path "$PSScriptRoot")\.dotnetcli"
+    $env:DOTNET_INSTALL_DIR = Join-Path "$(Convert-Path "$PSScriptRoot")" ".dotnetcli"
 
     if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
         mkdir $env:DOTNET_INSTALL_DIR | Out-Null
-        $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
-        Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
-        & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
     }
 
+    $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
+    Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
+    & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
+
     $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
-    $dotnet   = "$env:DOTNET_INSTALL_DIR\dotnet"
-} else {
-    $dotnet   = "dotnet"
+    $dotnet = Join-Path "$env:DOTNET_INSTALL_DIR" "dotnet"
+}
+else {
+    $dotnet = "dotnet"
 }
 
 function DotNetRestore {
@@ -61,21 +62,9 @@ function DotNetRestore {
     }
 }
 
-function DotNetBuild {
-    param([string]$Project, [string]$Configuration, [string]$VersionSuffix)
-    if ($VersionSuffix) {
-        & $dotnet build $Project --output $OutputPath --framework $framework --configuration $Configuration --version-suffix "$VersionSuffix"
-    } else {
-        & $dotnet build $Project --output $OutputPath --framework $framework --configuration $Configuration
-    }
-    if ($LASTEXITCODE -ne 0) {
-        throw "dotnet build failed with exit code $LASTEXITCODE"
-    }
-}
-
 function DotNetTest {
     param([string]$Project)
-    & $dotnet test $Project --output $OutputPath --framework $framework --no-build
+    & $dotnet test $Project --output $OutputPath
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"
     }
@@ -85,9 +74,10 @@ function DotNetPublish {
     param([string]$Project)
     $publishPath = (Join-Path $OutputPath "publish")
     if ($VersionSuffix) {
-        & $dotnet publish $Project --output $publishPath --framework $framework --configuration $Configuration --version-suffix "$VersionSuffix"
-    } else {
-        & $dotnet publish $Project --output $publishPath --framework $framework --configuration $Configuration
+        & $dotnet publish $Project --output $publishPath --configuration $Configuration --version-suffix "$VersionSuffix"
+    }
+    else {
+        & $dotnet publish $Project --output $publishPath --configuration $Configuration
     }
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet publish failed with exit code $LASTEXITCODE"
@@ -103,18 +93,13 @@ if ($PatchVersion -eq $true) {
     }
 
     $gitRevision = (git rev-parse HEAD | Out-String).Trim()
-    $timestamp   = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssK")
+    $timestamp = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssK")
 
     $assemblyVersion = Get-Content ".\AssemblyVersion.cs" -Raw
     $assemblyVersionWithMetadata = "{0}using System.Reflection;`r`n`r`n[assembly: AssemblyMetadata(""CommitHash"", ""{1}"")]`r`n[assembly: AssemblyMetadata(""CommitBranch"", ""{2}"")]`r`n[assembly: AssemblyMetadata(""BuildTimestamp"", ""{3}"")]" -f $assemblyVersion, $gitRevision, $gitBranch, $timestamp
 
     Set-Content ".\AssemblyVersion.cs" $assemblyVersionWithMetadata -Encoding utf8
 }
-
-$projects = @(
-    (Join-Path $solutionPath "src\API\API.csproj"),
-    (Join-Path $solutionPath "tests\API.Tests\API.Tests.csproj")
-)
 
 $testProjects = @(
     (Join-Path $solutionPath "tests\API.Tests\API.Tests.csproj")
@@ -125,28 +110,19 @@ $publishProjects = @(
 )
 
 if ($RestorePackages -eq $true) {
-    Write-Host "Restoring NuGet packages for $($projects.Count) projects..." -ForegroundColor Green
-    ForEach ($project in $projects) {
-        DotNetRestore $project
-    }
+    Write-Host "Restoring NuGet packages for solution..." -ForegroundColor Green
+    DotNetRestore $solutionFile
 }
 
-Write-Host "Building $($projects.Count) projects..." -ForegroundColor Green
-ForEach ($project in $projects) {
-    DotNetBuild $project $Configuration $PrereleaseSuffix
+Write-Host "Publishing solution..." -ForegroundColor Green
+ForEach ($project in $publishProjects) {
+    DotNetPublish $project $Configuration $PrereleaseSuffix
 }
 
-if ($RunTests -eq $true) {
+if ($SkipTests -eq $false) {
     Write-Host "Testing $($testProjects.Count) project(s)..." -ForegroundColor Green
     ForEach ($project in $testProjects) {
         DotNetTest $project
-    }
-}
-
-if ($PublishWebsite -eq $true) {
-    Write-Host "Publishing $($publishProjects.Count) projects..." -ForegroundColor Green
-    ForEach ($project in $publishProjects) {
-        DotNetPublish $project $Configuration $PrereleaseSuffix
     }
 }
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference = "Stop"
 
 $solutionPath = Split-Path $MyInvocation.MyCommand.Definition
 $solutionFile = Join-Path $solutionPath "API.sln"
-$dotnetVersion = "2.0.0-preview1-005977"
+$dotnetVersion = "2.0.0-preview2-006497"
 
 if ($OutputPath -eq "") {
     $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"
@@ -44,7 +44,7 @@ if ($installDotNetSdk -eq $true) {
     }
 
     $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
-    Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
+    Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
     & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
 
     $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="xunit" value="https://www.myget.org/F/xunit/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,7 @@
-os: Visual Studio 2015
+os: Visual Studio 2017
 version: 1.0.{build}
 
 environment:
-  CLI_VERSION: 1.0.4
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
 
@@ -10,10 +9,15 @@ branches:
   only:
     - master
 
+cache:
+  - src\API\node_modules
+  - '%APPDATA%\npm\node_modules'
+  - '%APPDATA%\npm-cache'
+
 install:
-  - ps: npm install -g npm@3.10.6
-  - ps: npm install -g bower --loglevel=error
-  - ps: npm install -g gulp --loglevel=error
+  - ps: npm install -g npm@4.5.0 --loglevel=error
+  - ps: npm install -g bower@1.8.0 --loglevel=error
+  - ps: npm install -g gulp@3.9.1 --loglevel=error
 
 build_script:
   - ps: .\Build.ps1

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ while :; do
     shift
 done
 
-export CLI_VERSION="2.0.0-preview2-006497"
+export CLI_VERSION="2.0.0"
 export DOTNET_INSTALL_DIR="$root/.dotnetcli"
 export PATH="$DOTNET_INSTALL_DIR:$PATH"
 

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,56 @@
-#!/bin/sh
-export artifacts=$(dirname "$(readlink -f "$0")")/artifacts
-export configuration=Release
+#!/usr/bin/env bash
 
-dotnet restore --verbosity minimal || exit 1
-dotnet build --output $artifacts --configuration $configuration || exit 1
-dotnet test tests/API.Tests/API.Tests.csproj --output $artifacts --configuration $configuration || exit 1
-dotnet publish src/API/API.csproj --output $artifacts --configuration $configuration || exit 1
+root=$(cd "$(dirname "$0")"; pwd -P)
+artifacts=$root/artifacts
+configuration=Release
+
+restorePackages=0
+skipTests=0
+
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -\?|-h|--help)
+            echo "./build.sh [--restore-packages] [--skip-tests]"
+            exit 1
+            ;;
+
+        --restore-packages)
+            restorePackages=1
+            ;;
+
+        --skip-tests)
+            skipTests=1
+            ;;
+
+        *)
+            __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"
+            ;;
+    esac
+
+    shift
+done
+
+export CLI_VERSION="2.0.0-preview1-005977"
+export DOTNET_INSTALL_DIR="$root/.dotnetcli"
+export PATH="$DOTNET_INSTALL_DIR:$PATH"
+
+dotnet_version=$(dotnet --version)
+
+if [ "$dotnet_version" != "$CLI_VERSION" ]; then
+    curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+fi
+
+if [ $restorePackages == 1 ]; then
+    dotnet restore ./API.sln --verbosity minimal || exit 1
+fi
+
+dotnet publish ./src/API/API.csproj --output $artifacts/publish --configuration $configuration || exit 1
+
+if [ $skipTests == 0 ]; then
+    dotnet test ./tests/API.Tests/API.Tests.csproj --output $artifacts --configuration $configuration || exit 1
+fi

--- a/build.sh
+++ b/build.sh
@@ -35,14 +35,14 @@ while :; do
     shift
 done
 
-export CLI_VERSION="2.0.0-preview1-005977"
+export CLI_VERSION="2.0.0-preview2-006497"
 export DOTNET_INSTALL_DIR="$root/.dotnetcli"
 export PATH="$DOTNET_INSTALL_DIR:$PATH"
 
 dotnet_version=$(dotnet --version)
 
 if [ "$dotnet_version" != "$CLI_VERSION" ]; then
-    curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+    curl -sSL https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 fi
 
 if [ $restorePackages == 1 ]; then

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "2.0.0-preview2-006497"
+    "version": "2.0.0"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "1.0.1"
+    "version": "2.0.0-preview2-006497"
   }
 }

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Description>https://api.martincostello.com/</Description>
     <OutputType>Exe</OutputType>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <Summary>Martin Costello's API</Summary>
@@ -15,24 +14,24 @@
     <Content Update="wwwroot\**\*;Views\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0-preview1-final" />
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0-preview2-final" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="1.0.5" />
     <PackageReference Include="Autofac" Version="4.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0-preview2-final" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NodaTime" Version="2.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Swashbuckle.Swagger" Version="6.0.0-beta901" />

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -14,22 +14,17 @@
     <Content Update="wwwroot\**\*;Views\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0-preview2-final" />
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="1.0.5" />
     <PackageReference Include="Autofac" Version="4.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NodaTime" Version="2.0.2" />
@@ -42,10 +37,5 @@
     <Exec Command="npm install --loglevel=error" Condition=" '$(InstallWebPackages)' == 'true' " />
     <Exec Command="bower install --loglevel=error" Condition=" '$(InstallWebPackages)' == 'true' " />
     <Exec Command="gulp publish" />
-  </Target>
-  <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths" DependsOnTargets="PrepareForPublish">
-    <ItemGroup>
-      <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
-    </ItemGroup>
   </Target>
 </Project>

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -48,8 +48,8 @@
     <PackageReference Include="Swashbuckle.SwaggerUi" Version="6.0.0-beta901" />
   </ItemGroup>
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
-    <Exec Command="npm install --loglevel=error" />
-    <Exec Command="bower install --loglevel=error" />
+    <Exec Command="npm install --loglevel=error" Condition=" '$(InstallWebPackages)' == 'true' " />
+    <Exec Command="bower install --loglevel=error" Condition=" '$(InstallWebPackages)' == 'true' " />
     <Exec Command="gulp publish" />
   </Target>
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths" DependsOnTargets="PrepareForPublish">

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <Summary>Martin Costello's API</Summary>
     <UserSecretsId>api.martincostello.com</UserSecretsId>
   </PropertyGroup>
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="NodaTime" Version="2.0.1" />
+    <PackageReference Include="NodaTime" Version="2.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Swashbuckle.Swagger" Version="6.0.0-beta901" />
     <PackageReference Include="Swashbuckle.SwaggerGen" Version="6.0.0-beta901" />

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -15,30 +15,22 @@
     <Content Update="wwwroot\**\*;Views\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.0" />
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0-preview1-final" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="1.0.5" />
     <PackageReference Include="Autofac" Version="4.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="NodaTime" Version="2.0.2" />

--- a/src/API/Controllers/HomeController.cs
+++ b/src/API/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.Api.Controllers
@@ -8,6 +8,7 @@ namespace MartinCostello.Api.Controllers
     using Extensions;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Primitives;
 
     /// <summary>
     /// A class representing the controller for the <c>/</c> resource.
@@ -56,8 +57,8 @@ namespace MartinCostello.Api.Controllers
         /// </returns>
         private bool IsJsonRequest()
         {
-            string mediaType = Request.GetTypedHeaders().Accept?.FirstOrDefault()?.MediaType;
-            return string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase);
+            var mediaType = Request.GetTypedHeaders().Accept?.FirstOrDefault()?.MediaType ?? StringSegment.Empty;
+            return StringSegment.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/API/Controllers/HomeController.cs
+++ b/src/API/Controllers/HomeController.cs
@@ -57,8 +57,8 @@ namespace MartinCostello.Api.Controllers
         /// </returns>
         private bool IsJsonRequest()
         {
-            var mediaType = Request.GetTypedHeaders().Accept?.FirstOrDefault()?.MediaType ?? StringSegment.Empty;
-            return StringSegment.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase);
+            var mediaType = Request.GetTypedHeaders().Accept?.FirstOrDefault()?.MediaType ?? string.Empty;
+            return mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.Api
@@ -8,6 +8,7 @@ namespace MartinCostello.Api
     using System.Threading;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// A class representing the entry-point to the application. This class cannot be inherited.
@@ -45,6 +46,14 @@ namespace MartinCostello.Api
                     .UseConfiguration(configuration)
                     .UseContentRoot(Directory.GetCurrentDirectory())
                     .UseIISIntegration()
+                    .ConfigureLogging(
+                        (hostingContext, factory) =>
+                        {
+                            if (hostingContext.HostingEnvironment.IsDevelopment())
+                            {
+                                factory.AddDebug();
+                            }
+                        })
                     .UseStartup<Startup>()
                     .CaptureStartupErrors(true);
 

--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -58,7 +58,7 @@ namespace MartinCostello.Api
                             e.Cancel = true;
                         };
 
-                        host.Run(tokenSource.Token);
+                        host.RunAsync(tokenSource.Token).GetAwaiter().GetResult();
                     }
                 }
 

--- a/src/API/Startup.cs
+++ b/src/API/Startup.cs
@@ -75,17 +75,16 @@ namespace MartinCostello.Api
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/> to use.</param>
         /// <param name="environment">The <see cref="IHostingEnvironment"/> to use.</param>
-        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
-        public void Configure(IApplicationBuilder app, IHostingEnvironment environment, ILoggerFactory loggerFactory)
+        /// <param name="loggerFactory">The <see cref="LoggerFactory"/> to use.</param>
+        public void Configure(IApplicationBuilder app, IHostingEnvironment environment, LoggerFactory loggerFactory)
         {
-            loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-
             app.UseCustomHttpHeaders(environment, Configuration, ServiceProvider.GetRequiredService<SiteOptions>());
 
             ////app.UseMiddleware<CustomIpRateLimitMiddleware>();
 
             if (environment.IsDevelopment())
             {
+                loggerFactory.AddConsole();
                 loggerFactory.AddDebug();
 
                 app.UseDeveloperExceptionPage();

--- a/src/API/Startup.cs
+++ b/src/API/Startup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.Api
@@ -75,8 +75,8 @@ namespace MartinCostello.Api
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/> to use.</param>
         /// <param name="environment">The <see cref="IHostingEnvironment"/> to use.</param>
-        /// <param name="loggerFactory">The <see cref="LoggerFactory"/> to use.</param>
-        public void Configure(IApplicationBuilder app, IHostingEnvironment environment, LoggerFactory loggerFactory)
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
+        public void Configure(IApplicationBuilder app, IHostingEnvironment environment, ILoggerFactory loggerFactory)
         {
             app.UseCustomHttpHeaders(environment, Configuration, ServiceProvider.GetRequiredService<SiteOptions>());
 
@@ -84,9 +84,6 @@ namespace MartinCostello.Api
 
             if (environment.IsDevelopment())
             {
-                loggerFactory.AddConsole();
-                loggerFactory.AddDebug();
-
                 app.UseDeveloperExceptionPage();
             }
             else
@@ -147,10 +144,11 @@ namespace MartinCostello.Api
             services.AddAntiforgery(
                 (p) =>
                 {
-                    p.CookieName = "_anti-forgery";
+                    p.Cookie.HttpOnly = true;
+                    p.Cookie.Name = "_anti-forgery";
+                    p.Cookie.SecurePolicy = CreateCookieSecurePolicy();
                     p.FormFieldName = "_anti-forgery";
                     p.HeaderName = "x-anti-forgery";
-                    p.RequireSsl = !HostingEnvironment.IsDevelopment();
                 });
 
             services.AddMemoryCache()
@@ -260,8 +258,22 @@ namespace MartinCostello.Api
             return new CookiePolicyOptions()
             {
                 HttpOnly = HttpOnlyPolicy.Always,
-                Secure = HostingEnvironment.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always,
+                Secure = CreateCookieSecurePolicy(),
             };
+        }
+
+        /// <summary>
+        /// Creates the <see cref="CookieSecurePolicy"/> to use.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="CookieSecurePolicy"/> to use for the application.
+        /// </returns>
+        private CookieSecurePolicy CreateCookieSecurePolicy()
+        {
+            return
+                HostingEnvironment.IsDevelopment() ?
+                CookieSecurePolicy.SameAsRequest :
+                CookieSecurePolicy.Always;
         }
     }
 }

--- a/tests/API.Tests/API.Tests.csproj
+++ b/tests/API.Tests/API.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\API.Common.props" />
   <PropertyGroup>
     <Description>Tests for https://api.martincostello.com/</Description>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <Summary>Tests for Martin Costello's API</Summary>
   </PropertyGroup>
   <ItemGroup>
@@ -14,8 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NodaTime" Version="2.0.1" />
-    <PackageReference Include="NodaTime.Testing" Version="2.0.1" />
+    <PackageReference Include="NodaTime.Testing" Version="2.0.2" />
     <PackageReference Include="Shouldly" Version="2.8.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.2.0" />

--- a/tests/API.Tests/API.Tests.csproj
+++ b/tests/API.Tests/API.Tests.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\..\src\API\API.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NodaTime.Testing" Version="2.0.2" />
     <PackageReference Include="Shouldly" Version="2.8.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />


### PR DESCRIPTION
  1. Update to use .NET Core 2.0 (`preview1-005977`).
  1. Refactor `Build.ps1` to be more efficient and improve runtime installation.
  1. Refactor `build.sh` to be functionally equivalent to `Build.ps1`.
  1. Update to NodaTime `2.0.2`.
  1. Update Visual Studio 2017 in AppVeyor.
  1. Cache npm and NuGet packages in AppVeyor and Travis.
  1. Remove redundant environment variables.
  1. Update npm.
  1. Pin the gulp and bower version.