### PR TITLE
Fix duplicate HTTP header

### DIFF
--- a/src/API/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/API/Middleware/CustomHttpHeadersMiddleware.cs
@@ -93,8 +93,6 @@ namespace MartinCostello.Api.Middleware
 
                     if (context.Request.IsHttps)
                     {
-                        context.Response.Headers.Add("Strict-Transport-Security", "max-age=31536000");
-
                         if (!string.IsNullOrWhiteSpace(_publicKeyPins))
                         {
                             context.Response.Headers.Add("Public-Key-Pins-Report-Only", _publicKeyPins);

--- a/src/API/Startup.cs
+++ b/src/API/Startup.cs
@@ -76,7 +76,7 @@ namespace MartinCostello.Api
             }
 
             app.UseHsts()
-                .UseHttpsRedirection();
+               .UseHttpsRedirection();
 
             app.UseStaticFiles(
                 new StaticFileOptions()


### PR DESCRIPTION
Fix the `Strict-Transport-Security` HTTP response header being added twice and causing an exception.

Caused by changes in #71.