### PR TITLE
Enable in-process IIS hosting

### DIFF
--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <!--
     <AspNetCoreHostingModel>inprocess</AspNetCoreHostingModel>
-    -->
-    <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
-    <AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>
     <DebugType>full</DebugType>
     <Description>https://api.martincostello.com/</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Re-enable the use of IIS in-process hosting.

Can merge once ANCM v2 is deployed to Azure App Service.