### PR TITLE
Publish cobertura coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
 after_build:
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
   - pip install codecov
-  - codecov -f "artifacts\coverage.opencover.xml"
+  - codecov -f "artifacts\coverage.cobertura.xml"
 
 artifacts:
   - path: artifacts\publish


### PR DESCRIPTION
Publish the cobertura output to `codecov.io`.