### PR TITLE
Simplify AppService dependency

### DIFF
--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.2" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="3.0.0" />
     <PackageReference Include="NodaTime" Version="2.4.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />

--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -47,7 +47,6 @@ namespace MartinCostello.Api
                     (webBuilder) =>
                     {
                         webBuilder.CaptureStartupErrors(true)
-                                  .UseAzureAppServices()
                                   .UseStartup<Startup>();
                     });
         }


### PR DESCRIPTION
Use Microsoft.AspNetCore.AzureAppServices.HostingStartup to automatically register AppService logging.