### PR TITLE
Remove redundant target

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -31,20 +31,4 @@
       </AssemblyAttribute>
     </ItemGroup>
   </Target>
-  <Target Name="GitMetadataAssemblyInfoCacheFileFix"
-          BeforeTargets="CreateGeneratedAssemblyInfoInputsCacheFile"
-          Condition=" '$(GenerateGitMetadata)' == 'true' ">
-    <ItemGroup>
-      <AssemblyAttribute Include="TemporaryAdditionalHashItem" Condition=" $(CommitHash) != '' or $(CommitBranch) != '' ">
-        <_Parameter1>$(CommitHash);$(CommitBranch)</_Parameter1>
-      </AssemblyAttribute>
-    </ItemGroup>
-  </Target>
-  <Target Name="CleanupTemporaryAdditionalHashItem"
-          AfterTargets="CreateGeneratedAssemblyInfoInputsCacheFile;AddGitMetadaAssemblyAttributes"
-          Condition=" '$(GenerateGitMetadata)' == 'true' ">
-    <ItemGroup>
-      <AssemblyAttribute Remove="TemporaryAdditionalHashItem" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
Remove MSBuild target that isn't needed with MSBuild 16.x.