### PR TITLE
Fix footer link

### DIFF
--- a/src/API/Views/Shared/_Footer.cshtml
+++ b/src/API/Views/Shared/_Footer.cshtml
@@ -12,7 +12,7 @@
             @GitMetadata.Branch
         </a>
         by
-        <a href="@Options.Metadata?.Repository/runs/@GitMetadata.DeployId" title="View deployment on GitHub">
+        <a href="@Options.Metadata?.Repository/actions/runs/@GitMetadata.DeployId" title="View deployment on GitHub">
             GitHub
         </a>
         <span id="build-date" data-format="YYYY-MM-DD HH:mm Z" data-timestamp="@GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture)"></span>


### PR DESCRIPTION
Fix the URL for the deployment footer link as it wasn't clear which of the two Ids the one in the environment variable was from the documentation.
