### PR TITLE
Update Roslyn analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <AnalyzersVersion>2.9.8</AnalyzersVersion>
+    <AnalyzersVersion>3.0.0</AnalyzersVersion>
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />


### PR DESCRIPTION
Update to the latest major release of the Roslyn code analyzers.

Replaces #349.
