### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
 updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+    timezone: Europe/London
+  reviewers:
+    - "martincostello"
 - package-ecosystem: npm
   directory: "/src/API"
   schedule:


### PR DESCRIPTION
Enable Dependabot to keep GitHub Actions up-to-date ([docs](https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot)).
