### PR TITLE
Add extensions.json for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "ms-dotnettools.csharp"
+  ]
+}

--- a/API.sln
+++ b/API.sln
@@ -32,6 +32,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "API.Tests", "tests\API.Test
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".vscode", ".vscode", "{C9381C1E-F8B9-4A77-B314-6DD8F370AF0E}"
 	ProjectSection(SolutionItems) = preProject
+		.vscode\extensions.json = .vscode\extensions.json
 		.vscode\launch.json = .vscode\launch.json
 		.vscode\tasks.json = .vscode\tasks.json
 	EndProjectSection


### PR DESCRIPTION
Add an `extensions.json` file to suggest extensions when opening the project in Visual Studio Code.