### PR TITLE
Fix .NET SDK update script

### DIFF
--- a/update-dotnet-sdk.ps1
+++ b/update-dotnet-sdk.ps1
@@ -80,11 +80,7 @@ function Get-Global-Json-Version([string] $FileName) {
     return $Version
 }
 
-function Get-Latest-SDK-Version()
-{
-    param([string] $FileName)
-    {
-    }
+function Get-Latest-SDK-Version([string] $FileName) {
 
     if (-Not (Test-Path $FileName)) {
         throw "Unable to find '$FileName'"


### PR DESCRIPTION
Revert change from 4127cf5e928edffc871b1d55c500f6eccadb1131 that broke the script.
