### PR TITLE
Homepage updates

### DIFF
--- a/src/API/Extensions/IServiceCollectionExtensions.cs
+++ b/src/API/Extensions/IServiceCollectionExtensions.cs
@@ -77,12 +77,11 @@ namespace MartinCostello.Api.Extensions
         /// <param name="fileName">The XML comments file name to try to add.</param>
         private static void AddXmlCommentsIfExists(SwaggerGenOptions options, IWebHostEnvironment environment, string fileName)
         {
-            var modelType = typeof(Startup).GetTypeInfo();
             string applicationPath;
 
             if (environment.IsDevelopment())
             {
-                applicationPath = Path.GetDirectoryName(modelType.Assembly.Location) ?? ".";
+                applicationPath = Path.GetDirectoryName(typeof(Startup).Assembly.Location) ?? ".";
             }
             else
             {

--- a/src/API/GitMetadata.cs
+++ b/src/API/GitMetadata.cs
@@ -43,7 +43,7 @@ namespace MartinCostello.Api
         /// </returns>
         private static string GetMetadataValue(string name, string defaultValue)
         {
-            return typeof(GitMetadata).GetTypeInfo().Assembly
+            return typeof(GitMetadata).Assembly
                 .GetCustomAttributes<AssemblyMetadataAttribute>()
                 .Where((p) => string.Equals(p.Key, name, StringComparison.Ordinal))
                 .Select((p) => p.Value)

--- a/src/API/Views/Home/Index.cshtml
+++ b/src/API/Views/Home/Index.cshtml
@@ -2,7 +2,7 @@
 @{
     ViewBag.Title = "Home Page";
     string? mvcVersion = typeof(Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions)
-        .GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        .Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
     SiteOptions options = Options.Value;
 }
 <div class="jumbotron">

--- a/src/API/Views/Home/Index.cshtml
+++ b/src/API/Views/Home/Index.cshtml
@@ -8,7 +8,7 @@
 <div class="jumbotron">
     <h1>Martin Costello's API</h1>
     <p class="lead">
-        This website is an excercise in the use of ASP.NET Core @Environment.Version.ToString(2) for a website and REST API.
+        This website is an excercise in the use of ASP.NET @Environment.Version.ToString(2) for a website and REST API.
     </p>
 </div>
 <div>
@@ -17,7 +17,7 @@
         and the source code can be found on <a href="@options.Metadata?.Repository" rel="noopener" target="_blank" title="This application's GitHub repository">GitHub</a>.
     </p>
     <p>
-        It is currently running <a href="https://github.com/dotnet/aspnetcore" rel="noopener" target="_blank" title="ASP.NET Core on GitHub">ASP.NET Core @mvcVersion</a>.
+        It is currently running <a href="https://github.com/dotnet/aspnetcore" rel="noopener" target="_blank" title="ASP.NET on GitHub">ASP.NET @mvcVersion</a>.
     </p>
 </div>
 <div class="row">

--- a/src/API/Views/Home/Index.cshtml
+++ b/src/API/Views/Home/Index.cshtml
@@ -17,7 +17,7 @@
         and the source code can be found on <a href="@options.Metadata?.Repository" rel="noopener" target="_blank" title="This application's GitHub repository">GitHub</a>.
     </p>
     <p>
-        It is currently running <a href="https://github.com/dotnet/aspnetcore" rel="noopener" target="_blank" title="ASP.NET on GitHub">ASP.NET @mvcVersion</a>.
+        It is currently running <a href="https://github.com/dotnet/aspnetcore/tree/@(mvcVersion?.Split('+').ElementAtOrDefault(1) ?? "master")" rel="noopener" target="_blank" title="ASP.NET on GitHub">ASP.NET @(mvcVersion?.Split('+').FirstOrDefault())</a>.
     </p>
 </div>
 <div class="row">

--- a/src/API/Views/Home/Index.cshtml
+++ b/src/API/Views/Home/Index.cshtml
@@ -17,7 +17,7 @@
         and the source code can be found on <a href="@options.Metadata?.Repository" rel="noopener" target="_blank" title="This application's GitHub repository">GitHub</a>.
     </p>
     <p>
-        It is currently running <a href="https://github.com/aspnet/AspNetCore" rel="noopener" target="_blank" title="ASP.NET Core on GitHub">ASP.NET Core @mvcVersion</a>.
+        It is currently running <a href="https://github.com/dotnet/aspnetcore" rel="noopener" target="_blank" title="ASP.NET Core on GitHub">ASP.NET Core @mvcVersion</a>.
     </p>
 </div>
 <div class="row">


### PR DESCRIPTION
  * Do not render the Git SHA in the text.
  * Render the commit of the build in the link, rather than just the current commit of the default branch.
  * Rebrand from "ASP.NET Core" to "ASP .NET" to match .NET 5.
  * Use the updated link to the ASP.NET Core repo.
  * Remove redundant usage of `GetTypeInfo()`.