### PR TITLE
Use azure/webapps-deploy@v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         flags: ${{ matrix.codecov_os }}
 
     - name: 'Deploy to Azure App Service'
-      uses: azure/webapps-deploy@v2.1.3
+      uses: azure/webapps-deploy@v2
       if: ${{ github.ref == 'refs/heads/deploy' && runner.os == 'Windows' }}
       with:
         app-name: apimartincostello-uksouth


### PR DESCRIPTION
Use azure/webapps-deploy@v2 to resolve warning about use of `set-env`.
