### PR TITLE
Split build and deploy workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main, deploy ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -45,11 +45,3 @@ jobs:
       with:
         file: ./artifacts/coverage.cobertura.xml
         flags: ${{ matrix.codecov_os }}
-
-    - name: 'Deploy to Azure App Service'
-      uses: azure/webapps-deploy@v2
-      if: ${{ github.ref == 'refs/heads/deploy' && runner.os == 'Windows' }}
-      with:
-        app-name: apimartincostello-uksouth
-        package: './artifacts/publish'
-        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE  }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,34 @@
 name: deploy
-on: [workflow_dispatch]
+
+on:
+  push:
+    branches: [ deploy ]
+  workflow_dispatch:
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: 'main'
-      - name: Sync main with deploy
-        run: |
-          git fetch origin main:deploy
-          git push origin deploy
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1.7.2
+
+    - name: Build and Publish
+      shell: pwsh
+      run: ./build.ps1 -SkipTests
+      env:
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+        NUGET_XMLDOC_MODE: skip
+
+    - name: 'Deploy to Azure App Service'
+      uses: azure/webapps-deploy@v2
+      if: ${{ github.ref == 'refs/heads/deploy' && runner.os == 'Windows' }}
+      with:
+        app-name: apimartincostello-uksouth
+        package: './artifacts/publish'
+        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE  }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://github.com/martincostello/api/workflows/Build/badge.svg?branch=main&event=push)](https://github.com/martincostello/api/actions?query=workflow%3ABuild+branch%3Amain+event%3Apush)
 
-[![Deploy status](https://github.com/martincostello/api/workflows/Build/badge.svg?branch=deploy&event=push)](https://github.com/martincostello/api/actions?query=workflow%3ABuild+branch%3Adeploy+event%3Apush)
+[![Deploy status](https://github.com/martincostello/api/workflows/deploy/badge.svg?branch=deploy&event=push)](https://github.com/martincostello/api/actions?query=workflow%3Adeploy+branch%3Adeploy+event%3Apush)
 
 ## Overview
 


### PR DESCRIPTION
Split out the workflows so that `build` only happens on main and for PRs, and `deploy` runs on deploy and just builds and publishes the code for Windows, rather than also running the tests and running the macOS and Linux builds too.
