### PR TITLE
Use release for tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,6 @@ jobs:
 
     - name: Run end-to-end tests
       shell: pwsh
-      run: dotnet test ./tests/API.Tests --filter Category=EndToEnd /p:CollectCoverage=false
+      run: dotnet test ./tests/API.Tests --configuration Release --filter Category=EndToEnd /p:CollectCoverage=false
       env:
         WEBSITE_URL: ${{ env.WEBSITE_URL_PROD }}


### PR DESCRIPTION
Build the end-to-end tests in Release instead of Debug.
