### PR TITLE
Add end-to-end test concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,8 @@ jobs:
   test:
     name: test-production
     needs: deploy
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
+    concurrency: production_environment
 
     steps:
 


### PR DESCRIPTION
- Use the same concurrency for deployment as the tests to try and prevent subsequent deployments running while the tests from the previous deployment are still running.
- Run end-to-end tests on Linux.