### PR TITLE
Use one property for ASP.NET Core version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <MicrosoftAspNetCoreVersion>6.0.5</MicrosoftAspNetCoreVersion>
     <NodaTimeVersion>3.1.0</NodaTimeVersion>
     <SwashbuckleAspNetCoreVersion>6.3.1</SwashbuckleAspNetCoreVersion>
   </PropertyGroup>
@@ -9,8 +10,8 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="1.4.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.2.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="6.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NodaTime" Version="$(NodaTimeVersion)" />


### PR DESCRIPTION
Use a single MSBuild property for the version of all packages built from the dotnet/aspnetcore repo.

This should reduce merge conflicts and make #808 easier to keep up-to-date.
