### PR TITLE
Update to Bootstrap 5

### DIFF
--- a/.github/workflows/update-static-assets.yml
+++ b/.github/workflows/update-static-assets.yml
@@ -1,0 +1,25 @@
+name: update-static-assets
+
+on:
+  schedule:
+    - cron:  '0 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-static-assets:
+    name: Update static assets
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Update static assets
+      uses: martincostello/update-static-assets@main
+      if: ${{ github.repository_owner == 'martincostello' }}
+      with:
+        labels: "dependencies"
+        repo-token: ${{ secrets.ACCESS_TOKEN }}
+        user-email: 102549341+costellobot@users.noreply.github.com
+        user-name: costellobot

--- a/API.sln
+++ b/API.sln
@@ -44,6 +44,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "API.Benchmarks", "tests\API.Benchmarks\API.Benchmarks.csproj", "{CD554D6A-45C2-42EA-9422-D2FAAD5AEF1F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{FBD1DEA8-994C-4AA8-A554-876D6D6B7EAA}"
+	ProjectSection(SolutionItems) = preProject
+		.github\dependabot.yml = .github\dependabot.yml
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{F414510B-EBC9-47DF-B561-EFE83A0CCECF}"
 	ProjectSection(SolutionItems) = preProject
@@ -51,6 +54,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		.github\workflows\update-dotnet-sdk.yml = .github\workflows\update-dotnet-sdk.yml
+		.github\workflows\update-static-assets.yml = .github\workflows\update-static-assets.yml
 	EndProjectSection
 EndProject
 Global

--- a/src/API/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/API/Middleware/CustomHttpHeadersMiddleware.cs
@@ -122,11 +122,11 @@ public sealed class CustomHttpHeadersMiddleware
     private static string BuildContentSecurityPolicy(bool isProduction, SiteOptions options)
     {
         string basePolicy = $@"
-default-src 'self' stackpath.bootstrapcdn.com;
-script-src 'self' ajax.googleapis.com cdnjs.cloudflare.com stackpath.bootstrapcdn.com www.googletagmanager.com 'unsafe-inline';
-style-src 'self' ajax.googleapis.com cdnjs.cloudflare.com fonts.googleapis.com stackpath.bootstrapcdn.com 'unsafe-inline';
+default-src 'self';
+script-src 'self' ajax.googleapis.com cdnjs.cloudflare.com www.googletagmanager.com 'unsafe-inline';
+style-src 'self' ajax.googleapis.com cdnjs.cloudflare.com fonts.googleapis.com 'unsafe-inline';
 img-src 'self' data: online.swagger.io www.googletagmanager.com {GetCdnOriginForContentSecurityPolicy(options)};
-font-src 'self' ajax.googleapis.com fonts.googleapis.com fonts.gstatic.com stackpath.bootstrapcdn.com;
+font-src 'self' ajax.googleapis.com fonts.googleapis.com fonts.gstatic.com;
 connect-src 'self' region1.google-analytics.com www.google-analytics.com;
 media-src 'none';
 object-src 'none';

--- a/src/API/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/API/Middleware/CustomHttpHeadersMiddleware.cs
@@ -75,7 +75,6 @@ public sealed class CustomHttpHeadersMiddleware
                 context.Response.Headers.Remove("X-Powered-By");
 
                 context.Response.Headers.Add("Content-Security-Policy", _contentSecurityPolicy);
-                context.Response.Headers.Add("Feature-Policy", "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'");
                 context.Response.Headers.Add("Permissions-Policy", "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()");
                 context.Response.Headers.Add("Referrer-Policy", "no-referrer-when-downgrade");
                 context.Response.Headers.Add("X-Content-Type-Options", "nosniff");

--- a/src/API/Pages/Home/Index.cshtml
+++ b/src/API/Pages/Home/Index.cshtml
@@ -7,11 +7,13 @@
         .Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
     SiteOptions options = Options.Value;
 }
-<div class="jumbotron">
-    <h1>Martin Costello's API</h1>
-    <p class="lead">
-        This website is an excercise in the use of ASP.NET Core @Environment.Version.ToString(1) for a website and REST API.
-    </p>
+<div class="bg-light mb-4 p-5 rounded-3">
+    <div class="container-fluid pt-2">
+        <h1 class="display-5 fw-bold">Martin Costello's API</h1>
+        <p class="col-md-8 fs-4">
+            This website is an excercise in the use of ASP.NET Core @Environment.Version.ToString(1) for a website and REST API.
+        </p>
+    </div>
 </div>
 <div>
     <p>

--- a/src/API/Pages/Shared/_Links.cshtml
+++ b/src/API/Pages/Shared/_Links.cshtml
@@ -23,14 +23,14 @@
 <environment names="Staging,Production">
     <link rel="dns-prefetch" href="//ajax.googleapis.com" />
     <link rel="dns-prefetch" href="//@options?.ExternalLinks?.Cdn?.Host" />
+    <link rel="dns-prefetch" href="//cdnjs.cloudflare.com" />
     <link rel="dns-prefetch" href="//fonts.googleapis.com" />
     <link rel="dns-prefetch" href="//fonts.gstatic.com" />
-    <link rel="dns-prefetch" href="//stackpath.bootstrapcdn.com" />
     <link rel="dns-prefetch" href="//www.googletagmanager.com" />
     <link rel="preconnect" href="//ajax.googleapis.com" />
     <link rel="preconnect" href="//@options?.ExternalLinks?.Cdn?.Host" />
+    <link rel="preconnect" href="//cdnjs.cloudflare.com" />
     <link rel="preconnect" href="//fonts.googleapis.com" />
     <link rel="preconnect" href="//fonts.gstatic.com" />
-    <link rel="preconnect" href="//stackpath.bootstrapcdn.com" />
     <link rel="preconnect" href="//www.googletagmanager.com" />
 </environment>

--- a/src/API/Pages/Shared/_Navbar.cshtml
+++ b/src/API/Pages/Shared/_Navbar.cshtml
@@ -1,22 +1,24 @@
 @{
     SiteOptions options = Options.Value;
 }
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <a id="link-home" href="/" class="navbar-brand">@options.Metadata?.Domain</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#site-navbar" aria-controls="site-navbar" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="site-navbar">
-        <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-                <a id="link-docs" href="/@options.Api?.Documentation?.Location" class="nav-link" title="My personal projects">Documentation</a>
-            </li>
-            <li class="nav-item">
-                <a id="link-blog-header" class="nav-link" href="@options.ExternalLinks?.Blog?.AbsoluteUri" rel="noopener" target="_blank" title="My blog">Blog</a>
-            </li>
-            <li class="nav-item">
-                <a id="link-about" class="nav-link" href="@(new Uri(new Uri(options.Metadata?.Author?.Website ?? string.Empty), "home/about/"))" rel="noopener" target="_blank" title="About me">About</a>
-            </li>
-        </ul>
+<nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
+    <div class="container">
+        <a id="link-home" href="/" class="navbar-brand">@options.Metadata?.Domain</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#site-navbar" aria-controls="site-navbar" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="site-navbar">
+            <ul class="navbar-nav me-auto">
+                <li class="nav-item">
+                    <a id="link-docs" href="/@options.Api?.Documentation?.Location" class="nav-link" title="My personal projects">Documentation</a>
+                </li>
+                <li class="nav-item">
+                    <a id="link-blog-header" class="nav-link" href="@options.ExternalLinks?.Blog?.AbsoluteUri" rel="noopener" target="_blank" title="My blog">Blog</a>
+                </li>
+                <li class="nav-item">
+                    <a id="link-about" class="nav-link" href="@(new Uri(new Uri(options.Metadata?.Author?.Website ?? string.Empty), "home/about/"))" rel="noopener" target="_blank" title="About me">About</a>
+                </li>
+            </ul>
+        </div>
     </div>
 </nav>

--- a/src/API/Pages/Shared/_Scripts.cshtml
+++ b/src/API/Pages/Shared/_Scripts.cshtml
@@ -1,5 +1,5 @@
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.0/js/bootstrap.bundle.min.js" integrity="sha512-9GacT4119eY3AcosfWtHMsT5JyZudrexyEVzTBWV3viP/YfB9e2pEy3N7WXL3SV6ASXpTU0vzzSxsbfsuUH4sQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.1/js/bootstrap.min.js" integrity="sha512-UR25UO94eTnCVwjbXozyeVd6ZqpaAE9naiEUBK/A+QDbfSTQFhPGj5lOR6d8tsgbBk84Ggb5A3EkjsOgPRPcKA==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.min.js" integrity="sha512-jNDtFf7qgU0eH/+Z42FG4fw3w7DM/9zbgNPe3wfJlCylVDTT3IgKW5r92Vy9IHa6U50vyMz5gRByIu4YIXFtaQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js" integrity="sha512-dGM81hdEjiW5IomkknOx3fIfwij3c7xwh6TcrbumlkHJtO81OKNjLISJaPEhCgVxM6+0uGJ7KRmI2YJFn0AmHQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
 @{

--- a/src/API/Pages/Shared/_Styles.cshtml
+++ b/src/API/Pages/Shared/_Styles.cshtml
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/4.4.0/flatly/bootstrap.min.css" integrity="sha384-mmD53kM+o1Gb3lEe5rP7tYMocTDMCrNf53Aiuqv2q+3ObpFCycuiCHtery6tYa2V" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.2.0/flatly/bootstrap.min.css" integrity="sha512-SAOc0O+NBGM2HuPF20h4nse270bwZJi8X90t5k/ApuB9oasBYEyLJ7WtYcWZARWiSlKJpZch1+ip2mmhvlIvzQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <environment names="Development">
     <link rel="stylesheet" href="~/assets/css/site.css" asp-append-version="true" />
 </environment>

--- a/src/API/assets/scripts/js/swagger.js
+++ b/src/API/assets/scripts/js/swagger.js
@@ -42,7 +42,6 @@
         responseInterceptor: function (response) {
           // Delete overly-verbose headers from the UI
           delete response.headers['content-security-policy'];
-          delete response.headers['feature-policy'];
           delete response.headers['permissions-policy'];
         }
       });

--- a/src/API/assets/styles/css/css.css
+++ b/src/API/assets/styles/css/css.css
@@ -15,7 +15,7 @@ a,
 }
 
 .body-content {
-  padding-top: 10px;
+  padding-top: 85px;
 }
 
 .response-col_status {

--- a/src/API/package-lock.json
+++ b/src/API/package-lock.json
@@ -8,7 +8,6 @@
       "name": "apimartincostellocom",
       "version": "6.0.0",
       "devDependencies": {
-        "bootstrap": "^5.2.0",
         "clean-css": "^5.3.1",
         "colors": "1.4.0",
         "del": "^6.1.1",
@@ -56,17 +55,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
-      "dev": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/aggregate-error": {
@@ -654,25 +642,6 @@
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
       }
     },
     "node_modules/brace-expansion": {
@@ -1431,9 +1400,9 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1536,9 +1505,9 @@
       }
     },
     "node_modules/ext/node_modules/type": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
       "dev": true
     },
     "node_modules/extend": {
@@ -2856,9 +2825,9 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -4050,14 +4019,14 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -5745,9 +5714,9 @@
       "dev": true
     },
     "node_modules/uglify-js": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
-      "integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
       "dev": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -6180,13 +6149,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
-      "dev": true,
-      "peer": true
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -6638,13 +6600,6 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
-    },
-    "bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
-      "dev": true,
-      "requires": {}
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -7281,9 +7236,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "dev": true,
       "requires": {
         "es6-iterator": "^2.0.3",
@@ -7370,9 +7325,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
           "dev": true
         }
       }
@@ -8440,9 +8395,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -9422,14 +9377,14 @@
       }
     },
     "object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
     },
@@ -10732,9 +10687,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
-      "integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
       "dev": true
     },
     "unc-path-regex": {

--- a/src/API/package.json
+++ b/src/API/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "6.0.0",
   "devDependencies": {
-    "bootstrap": "^5.2.0",
     "clean-css": "^5.3.1",
     "colors": "1.4.0",
     "del": "^6.1.1",

--- a/src/API/wwwroot/error.html
+++ b/src/API/wwwroot/error.html
@@ -10,7 +10,6 @@
     <meta name="language" content="en" />
     <meta name="robots" content="NOINDEX" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1" />
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/4.3.1/flatly/bootstrap.min.css" integrity="sha384-T5jhQKMh96HMkXwqVMSjF3CmLcL1nT9//tCqu9By5XSdj7CwR0r+F3LTzUdfkkQf" crossorigin="anonymous">
 </head>
 <body>
     <script type="text/javascript">
@@ -50,8 +49,7 @@
             </p>
         </footer>
     </div>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@4.5.2/dist/flatly/bootstrap.min.css" integrity="sha384-qF/QmIAj5ZaYFAeQcrQ6bfVMAh4zZlrGwTPY7T/M+iTTLJqJBJjwwnsE5Y0mV7QK" crossorigin="anonymous">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.1/js/bootstrap.min.js" integrity="sha512-UR25UO94eTnCVwjbXozyeVd6ZqpaAE9naiEUBK/A+QDbfSTQFhPGj5lOR6d8tsgbBk84Ggb5A3EkjsOgPRPcKA==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.2.0/flatly/bootstrap.min.css" integrity="sha512-SAOc0O+NBGM2HuPF20h4nse270bwZJi8X90t5k/ApuB9oasBYEyLJ7WtYcWZARWiSlKJpZch1+ip2mmhvlIvzQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.0/js/bootstrap.bundle.min.js" integrity="sha512-9GacT4119eY3AcosfWtHMsT5JyZudrexyEVzTBWV3viP/YfB9e2pEy3N7WXL3SV6ASXpTU0vzzSxsbfsuUH4sQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/tests/API.Tests/EndToEnd/ResourceTests.cs
+++ b/tests/API.Tests/EndToEnd/ResourceTests.cs
@@ -56,7 +56,6 @@ public class ResourceTests : EndToEndTest
         string[] expectedHeaders = new[]
         {
             "content-security-policy",
-            "feature-policy",
             "Permissions-Policy",
             "Referrer-Policy",
             "X-Content-Type-Options",

--- a/tests/API.Tests/Integration/ResourceTests.cs
+++ b/tests/API.Tests/Integration/ResourceTests.cs
@@ -82,7 +82,6 @@ public class ResourceTests : IntegrationTest
         string[] expectedHeaders = new[]
         {
             "content-security-policy",
-            "feature-policy",
             "Permissions-Policy",
             "Referrer-Policy",
             "X-Content-Type-Options",


### PR DESCRIPTION
- Upgrade from Bootstrap 4 to 5.
- Remove `Feature-Policy` as it causes a warning in Chrome when used with `Permissions-Policy`.
- Add a workflow to keep static CDN asserts up-to-date using [martincostello/update-static-assets](https://github.com/martincostello/update-static-assets).
