### PR TITLE
Run crank on Linux and refactor workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest ]
+        os: [ ubuntu-latest ]
 
     steps:
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,8 @@
 name: benchmark
 
+env:
+  CRANK_VERSION: '0.2.0-*'
+
 on:
   issue_comment:
     types: [ created ]
@@ -8,7 +11,7 @@ jobs:
   benchmark:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    if: github.repository == 'martincostello/api' && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/benchmark')
+    if: ${{ github.event.repository.fork == false && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/benchmark') }}
 
     strategy:
       fail-fast: false
@@ -83,7 +86,7 @@ jobs:
           const benchmark = arguments[1];
           core.info(`Benchmark: ${benchmark}`);
 
-          const start_body = `Started [${benchmark} benchmark](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}).`;
+          const start_body = `Started [${benchmark} benchmark](${{ github.server_url }}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}).`;
           await github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
@@ -102,13 +105,18 @@ jobs:
     - name: Install crank
       shell: pwsh
       run: |
-        dotnet tool install --global Microsoft.Crank.Agent --version "0.2.0-*"
-        dotnet tool install --global Microsoft.Crank.Controller --version "0.2.0-*"
-        dotnet tool install --global Microsoft.Crank.PullRequestBot --version "0.2.0-*"
+        dotnet tool install --global Microsoft.Crank.Agent --version "${{ env.CRANK_VERSION }}"
+        dotnet tool install --global Microsoft.Crank.Controller --version "${{ env.CRANK_VERSION }}"
+        dotnet tool install --global Microsoft.Crank.PullRequestBot --version "${{ env.CRANK_VERSION }}"
 
     - name: Run crank
       shell: pwsh
-      run: ./benchmark-crank.ps1 -Benchmark ${{ steps.benchmark-argument.outputs.result }} -Repository https://github.com/${{ github.repository }} -PullRequestId ${{ github.event.issue.number }} -AccessToken ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        ./benchmark-crank.ps1 `
+          -Benchmark "${{ steps.benchmark-argument.outputs.result }}" `
+          -Repository "${{ github.server_url }}/${{ github.repository }}" `
+          -PullRequestId "${{ github.event.issue.number }}" `
+          -AccessToken "${{ secrets.GITHUB_TOKEN }}"
       env:
         DOTNET_CLI_TELEMETRY_OPTOUT: true
         DOTNET_NOLOGO: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-    - '**/*.md'
-    - '**/*.gitignore'
     - '**/*.gitattributes'
+    - '**/*.gitignore'
+    - '**/*.md'
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -67,7 +67,7 @@ jobs:
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
 
   deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.event.repository.fork == false && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     name: deploy-production
     needs: build
     runs-on: windows-latest

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -10,6 +10,7 @@ jobs:
   update-dotnet-sdk:
     name: Update .NET SDK
     runs-on: ubuntu-latest
+    if: ${{ github.event.repository.fork == false }}
 
     steps:
 
@@ -18,7 +19,6 @@ jobs:
 
     - name: Update .NET SDK
       uses: martincostello/update-dotnet-sdk@v2.0.1
-      if: ${{ github.repository_owner == 'martincostello' }}
       with:
         labels: dependencies
         repo-token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/update-static-assets.yml
+++ b/.github/workflows/update-static-assets.yml
@@ -9,6 +9,7 @@ jobs:
   update-static-assets:
     name: Update static assets
     runs-on: ubuntu-latest
+    if: ${{ github.event.repository.fork == false }}
 
     steps:
 
@@ -17,7 +18,6 @@ jobs:
 
     - name: Update static assets
       uses: martincostello/update-static-assets@v1
-      if: ${{ github.repository_owner == 'martincostello' }}
       with:
         labels: "dependencies"
         repo-token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
- Run crank on Linux to try and rule out issues in another repo with cloning on Linux.
- Use variables for whether the repo is a fork and the default branch.
- Use variable for the crank version.
- Remove hard-coded GitHub URLs.
- Make workflows conditional, rather than just one step of them.
