### PR TITLE
Crank improvements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,9 +36,6 @@
     <VersionPrefix>6.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(CI)' != '' or !Exists('$(MSBuildThisFileDirectory)\src\API\node_modules') ">
-    <InstallWebPackages>true</InstallWebPackages>
-  </PropertyGroup>
   <ItemGroup>
     <Using Include="System.Globalization" />
   </ItemGroup>

--- a/benchmark.yml
+++ b/benchmark.yml
@@ -1,7 +1,7 @@
 components:
   api:
     script: |
-      pwsh build.ps1 -SkipTests
+      dotnet build --configuration Release
     arguments: ""
 
 defaults: --config ./crank.yml

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -22,7 +22,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
   </ItemGroup>
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
-    <Exec Command="npm ci" Condition=" '$(InstallWebPackages)' == 'true' or !Exists('$(MSBuildThisFileDirectory)\node_modules') " />
+    <Exec Command="npm ci" Condition=" !Exists('$(MSBuildThisFileDirectory)\node_modules') AND '$(GITHUB_ACTIONS)' != '' " />
+    <Exec Command="npm install" Condition=" !Exists('$(MSBuildThisFileDirectory)\node_modules') AND '$(GITHUB_ACTIONS)' == '' " />
     <Exec Command="npm run publish" Condition=" ('$(BuildingInsideVisualStudio)' != 'true' and '$(GITHUB_ACTIONS)' != 'true') or !Exists('$(MSBuildThisFileDirectory)\wwwroot\assets\js\site.js') " />
   </Target>
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths" Condition="'$(CI)' != ''">

--- a/src/API/appsettings.json
+++ b/src/API/appsettings.json
@@ -1,10 +1,13 @@
 {
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
-      "Microsoft": "Information",
-      "System": "Information"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager": "Error",
+      "Microsoft.AspNetCore.DataProtection.Repositories.EphemeralXmlRepository": "Error",
+      "Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository": "Error",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "System": "Warning"
     }
   },
   "Site": {


### PR DESCRIPTION
- Speed up the crank build by just running `dotnet build`, rather than `build.ps1`.
- Only run `npm install` once.
- Use `npm ci` in GitHub Actions.
- Fix over-verbose logging.
