### PR TITLE
Add missing channel argument

### DIFF
--- a/crank.yml
+++ b/crank.yml
@@ -9,6 +9,7 @@ jobs:
       repository: https://github.com/martincostello/api
       branchOrCommit: main
       project: src/API/API.csproj
+    channel: current
     readyStateText: Application started.
 
 scenarios:


### PR DESCRIPTION
Fix the crank benchmarks by specifying the channel to use for the `server` job.
