### PR TITLE
Fix .NET 8 analyzer warnings

### DIFF
--- a/src/API/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/API/Middleware/CustomHttpHeadersMiddleware.cs
@@ -81,7 +81,7 @@ public sealed class CustomHttpHeadersMiddleware
                 context.Response.Headers.XContentTypeOptions = "nosniff";
                 context.Response.Headers.Append("X-Datacenter", _datacenter);
                 context.Response.Headers.Append("X-Download-Options", "noopen");
-                context.Response.Headers.Append("X-Frame-Options", "DENY");
+                context.Response.Headers.XFrameOptions = "DENY";
                 context.Response.Headers.XXSSProtection = "1; mode=block";
 
 #if DEBUG


### PR DESCRIPTION
Cherry pick changes from https://github.com/martincostello/api/pull/1015 to resolve new analyser warnings for .NET 8.
