### PR TITLE
Use MSBuild Report Generator

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -32,4 +32,16 @@
       </AssemblyAttribute>
     </ItemGroup>
   </Target>
+  <PropertyGroup Condition=" '$(CollectCoverage)' == 'true' ">
+    <ReportGeneratorOutputMarkdown Condition=" '$(ReportGeneratorOutputMarkdown)' == '' AND '$(GITHUB_SHA)' != '' ">true</ReportGeneratorOutputMarkdown>
+    <ReportGeneratorReportTypes>HTML</ReportGeneratorReportTypes>
+    <ReportGeneratorReportTypes Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">$(ReportGeneratorReportTypes);MarkdownSummaryGitHub</ReportGeneratorReportTypes>
+    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(OutputPath), 'coverage-reports'))</ReportGeneratorTargetDirectory>
+    <_MarkdownSummaryPrefix>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_MarkdownSummaryPrefix>
+    <_MarkdownSummarySuffix>&lt;/details&gt;</_MarkdownSummarySuffix>
+  </PropertyGroup>
+  <Target Name="GenerateCoverageReports" AfterTargets="GenerateCoverageResultAfterTest" Condition=" '$(CollectCoverage)' == 'true' ">
+    <ReportGenerator ReportFiles="@(CoverletReport)" ReportTypes="$(ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
+    <Exec Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " Command="pwsh -Command %22('$(_MarkdownSummaryPrefix)' + [System.Environment]::NewLine + [System.Environment]::NewLine + (Get-Content $([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md')) | Out-String) + [System.Environment]::NewLine + [System.Environment]::NewLine + '$(_MarkdownSummarySuffix)') >> $(GITHUB_STEP_SUMMARY)%22" />
+  </Target>
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -78,14 +78,6 @@ if ($installDotNetSdk -eq $true) {
 function DotNetTest {
     param([string]$Project)
 
-    $nugetPath = $env:NUGET_PACKAGES ?? (Join-Path ($env:USERPROFILE ?? "~") ".nuget" "packages")
-    $propsFile = Join-Path $solutionPath "Directory.Packages.props"
-    $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageVersion[@Include='ReportGenerator']/@Version").Node.'#text'
-    $reportGeneratorPath = Join-Path $nugetPath "reportgenerator" $reportGeneratorVersion "tools" "net6.0" "ReportGenerator.dll"
-
-    $coverageOutput = Join-Path $OutputPath "coverage.cobertura.xml"
-    $reportOutput = Join-Path $OutputPath "coverage"
-
     $additionalArgs = @()
 
     if (![string]::IsNullOrEmpty($env:GITHUB_SHA)) {
@@ -95,19 +87,8 @@ function DotNetTest {
 
     & $dotnet test $Project --configuration "Release" --output $OutputPath $additionalArgs -- RunConfiguration.TestSessionTimeout=1200000
 
-    $dotNetTestExitCode = $LASTEXITCODE
-
-    if (Test-Path $coverageOutput) {
-        & $dotnet `
-            $reportGeneratorPath `
-            `"-reports:$coverageOutput`" `
-            `"-targetdir:$reportOutput`" `
-            -reporttypes:HTML `
-            -verbosity:Warning
-    }
-
-    if ($dotNetTestExitCode -ne 0) {
-        throw "dotnet test failed with exit code $dotNetTestExitCode"
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet test failed with exit code $LASTEXITCODE"
     }
 }
 


### PR DESCRIPTION
- Use the MSBuild version of ReportGenerator instead of running it from pwsh directly.
- Output the coverage summary when running in GitHub Actions.