### PR TITLE
Remove MicrosoftAspNetCoreVersion

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <MicrosoftAspNetCoreVersion>7.0.3</MicrosoftAspNetCoreVersion>
     <NodaTimeVersion>3.1.6</NodaTimeVersion>
     <SwashbuckleAspNetCoreVersion>6.5.0</SwashbuckleAspNetCoreVersion>
   </PropertyGroup>


### PR DESCRIPTION
Remove `MicrosoftAspNetCoreVersion` as it's not useful anymore with the .NET SDK update workflow.
