### PR TITLE
Use vars

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
         name: webapp
 
     - name: Deploy to Azure App Service
-      uses: azure/webapps-deploy@v2.2.9
+      uses: azure/webapps-deploy@v2
       id: deploy_production
       with:
         app-name: ${{ env.AZURE_WEBAPP_NAME }}

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -1,8 +1,9 @@
 name: update-dotnet-sdk
 
 env:
-  GIT_COMMIT_USER_EMAIL: 102549341+costellobot@users.noreply.github.com
-  GIT_COMMIT_USER_NAME: costellobot
+  ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+  GIT_COMMIT_USER_EMAIL: ${{ vars.GIT_COMMIT_USER_EMAIL }}
+  GIT_COMMIT_USER_NAME: ${{ vars.GIT_COMMIT_USER_NAME }}
   TERM: xterm
 
 on:
@@ -22,14 +23,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        token: ${{ secrets.ACCESS_TOKEN }}
+        token: ${{ env.ACCESS_TOKEN }}
 
     - name: Update .NET SDK
       id: update-dotnet-sdk
       uses: martincostello/update-dotnet-sdk@v2
       with:
         labels: "dependencies,.NET"
-        repo-token: ${{ secrets.ACCESS_TOKEN }}
+        repo-token: ${{ env.ACCESS_TOKEN }}
         user-email: ${{ env.GIT_COMMIT_USER_EMAIL }}
         user-name: ${{ env.GIT_COMMIT_USER_NAME }}
 
@@ -53,7 +54,7 @@ jobs:
 
         $tempPath = [System.IO.Path]::GetTempPath()
         $updatesPath = (Join-Path $tempPath "dotnet-outdated.json")
-        
+
         Write-Host "Checking for .NET NuGet package(s) to update..."
 
         dotnet outdated `
@@ -115,11 +116,11 @@ jobs:
 
           git config user.email "${{ env.GIT_COMMIT_USER_EMAIL }}"
           git config user.name "${{ env.GIT_COMMIT_USER_NAME }}"
-          
+
           git add .
           git commit -m $commitMessage
           git push
-          
+
           Write-Host "Pushed update to $($dependencies.Count) NuGet package(s)." -ForegroundColor Green
         }
         else {

--- a/.github/workflows/update-static-assets.yml
+++ b/.github/workflows/update-static-assets.yml
@@ -21,5 +21,5 @@ jobs:
       with:
         labels: "dependencies"
         repo-token: ${{ secrets.ACCESS_TOKEN }}
-        user-email: 102549341+costellobot@users.noreply.github.com
-        user-name: costellobot
+        user-email: ${{ vars.GIT_COMMIT_USER_EMAIL }}
+        user-name: ${{ vars.GIT_COMMIT_USER_NAME }}


### PR DESCRIPTION
- Move Git commit user values into `vars`.
- Use the v2 tag for the Azure Web App deployment action.
