### PR TITLE
Remove redundant suppressions

### DIFF
--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using MartinCostello.Api;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/tests/API.Benchmarks/Program.cs
+++ b/tests/API.Benchmarks/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using BenchmarkDotNet.Running;
 using MartinCostello.Api.Benchmarks;
 


### PR DESCRIPTION
Remove now-redundant suppressions for false-positive code analysis warnings.
