### PR TITLE
Prepare for .NET 8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,7 +48,7 @@
     <CollectCoverage Condition=" '$(WEBSITE_URL)' == '' ">true</CollectCoverage>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[xunit.*]*</Exclude>
-    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
-    <Threshold>55</Threshold>
+    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
+    <Threshold>60</Threshold>
   </PropertyGroup>
 </Project>

--- a/src/API/Swagger/ExampleFilter.cs
+++ b/src/API/Swagger/ExampleFilter.cs
@@ -74,9 +74,9 @@ internal sealed class ExampleFilter : IOperationFilter, IParameterFilter, ISchem
     /// <typeparam name="T">The type of the attribute(s) to find.</typeparam>
     /// <param name="apiDescription">The API description.</param>
     /// <returns>
-    /// An <see cref="IList{T}"/> containing any found attributes of type <typeparamref name="T"/>.
+    /// An array containing any found attributes of type <typeparamref name="T"/>.
     /// </returns>
-    private static IList<T> GetAttributes<T>(ApiDescription apiDescription)
+    private static T[] GetAttributes<T>(ApiDescription apiDescription)
         where T : Attribute
     {
         IEnumerable<T> attributes = Enumerable.Empty<T>();

--- a/tests/API.Tests/EndToEnd/ApiTests.cs
+++ b/tests/API.Tests/EndToEnd/ApiTests.cs
@@ -105,7 +105,7 @@ public class ApiTests : EndToEndTest
         // Assert
         response.EnsureSuccessStatusCode();
 
-        using var result = JsonDocument.Parse(await response.Content.ReadAsStreamAsync());
+        using var result = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
 
         result.RootElement.GetProperty("hash").GetString().ShouldBe(expected);
     }


### PR DESCRIPTION
- Exclude code decorated with `[GeneratedCode]` from code coverage.
- Fix code analysis warnings identified by #1219.
