### PR TITLE
Use char overload

### DIFF
--- a/src/API/Extensions/HttpRequestExtensions.cs
+++ b/src/API/Extensions/HttpRequestExtensions.cs
@@ -37,7 +37,7 @@ public static class HttpRequestExtensions
 
         string canonicalUri = builder.Uri.AbsoluteUri.ToLowerInvariant();
 
-        if (!canonicalUri.EndsWith("/", StringComparison.Ordinal))
+        if (!canonicalUri.EndsWith('/'))
         {
             canonicalUri += "/";
         }


### PR DESCRIPTION
Use overload of `EndsWith()` that accepts a `char`.
