### PR TITLE
Swap order of steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,17 +114,17 @@ jobs:
 
     steps:
 
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: webapp
+
     - name: Azure log in
       uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-    - name: Download artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: webapp
 
     - name: Deploy to Azure App Service
       uses: azure/webapps-deploy@v2


### PR DESCRIPTION
Login to Azure immediately before needing the credentials so that if downloading the Artifacts takes too long the JWT doesn't expire.
