### PR TITLE
Fix benchmarks

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -62,4 +62,4 @@ $benchmarks = (Join-Path $solutionPath "tests" "API.Benchmarks" "API.Benchmarks.
 
 Write-Host "Running benchmarks..." -ForegroundColor Green
 
-& $dotnet run --project $benchmarks --configuration "Release"
+& $dotnet run --project $benchmarks --configuration "Release" -- --filter '*'

--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -4,11 +4,13 @@
 #Requires -Version 7
 
 param(
-    [Parameter(Mandatory = $false)][string] $Configuration = "Release",
-    [Parameter(Mandatory = $false)][string] $Framework = "net8.0"
 )
 
 $ErrorActionPreference = "Stop"
+
+if ($null -eq $env:MSBUILDTERMINALLOGGER) {
+    $env:MSBUILDTERMINALLOGGER = "auto"
+}
 
 $solutionPath = $PSScriptRoot
 $sdkFile = Join-Path $solutionPath "global.json"
@@ -60,4 +62,4 @@ $benchmarks = (Join-Path $solutionPath "tests" "API.Benchmarks" "API.Benchmarks.
 
 Write-Host "Running benchmarks..." -ForegroundColor Green
 
-& $dotnet run --project $benchmarks --configuration $Configuration --framework $Framework
+& $dotnet run --project $benchmarks --configuration "Release"

--- a/tests/API.Benchmarks/API.Benchmarks.csproj
+++ b/tests/API.Benchmarks/API.Benchmarks.csproj
@@ -7,7 +7,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MartinCostello.API.Benchmarks</RootNamespace>
     <Summary>$(Description)</Summary>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\API\API.csproj" />

--- a/tests/API.Benchmarks/ApiBenchmarks.cs
+++ b/tests/API.Benchmarks/ApiBenchmarks.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Diagnosers;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 
 namespace MartinCostello.Api.Benchmarks;
 
-[EventPipeProfiler(EventPipeProfile.CpuSampling)]
-[MemoryDiagnoser]
+[Config(typeof(CustomBenchmarkConfig))]
 public class ApiBenchmarks : IAsyncDisposable
 {
     private WebApplication? _app;

--- a/tests/API.Benchmarks/CustomBenchmarkConfig.cs
+++ b/tests/API.Benchmarks/CustomBenchmarkConfig.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+
+namespace MartinCostello.Api.Benchmarks;
+
+public class CustomBenchmarkConfig : ManualConfig
+{
+    public CustomBenchmarkConfig()
+        : base()
+    {
+        var job = Job.Default
+            .WithId("API")
+            .WithArguments([new MsBuildArgument("/p:UseArtifactsOutput=false")]);
+
+        AddJob(job);
+        AddDiagnoser(MemoryDiagnoser.Default);
+        AddDiagnoser(new EventPipeProfiler(EventPipeProfile.CpuSampling));
+    }
+}


### PR DESCRIPTION
- Remove `--framework` argument.
- Disable `UseArtifactsOutput` for benchmarks.
- Fix no benchmarks being run.
