### PR TITLE
Consume .NET nightly builds

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,10 +11,10 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="MartinCostello.OpenApi.Extensions" Version="1.0.0-beta.306" />
-    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rtm.24511.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rtm.24511.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rtm.24511.11" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rtm.24511.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rtm.24514.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rtm.24514.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rtm.24514.7" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rtm.24514.7" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0-preview.9.24507.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,10 +11,10 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="MartinCostello.OpenApi.Extensions" Version="1.0.0-beta.306" />
-    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rtm.24508.22" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rtm.24508.22" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rtm.24508.22" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rtm.24508.22" />
+    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rtm.24509.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rtm.24509.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rtm.24509.6" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rtm.24509.6" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0-preview.9.24507.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,10 +11,10 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="MartinCostello.OpenApi.Extensions" Version="1.0.0-beta.306" />
-    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rtm.24509.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rtm.24509.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rtm.24509.6" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rtm.24509.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rtm.24511.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rtm.24511.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rtm.24511.11" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rtm.24511.11" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0-preview.9.24507.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,10 +11,10 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="MartinCostello.OpenApi.Extensions" Version="1.0.0-beta.306" />
-    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rtm.24508.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rtm.24508.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rtm.24508.4" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rtm.24508.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rtm.24508.22" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rtm.24508.22" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rtm.24508.22" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rtm.24508.22" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0-preview.9.24507.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,10 +11,10 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="MartinCostello.OpenApi.Extensions" Version="1.0.0-beta.306" />
-    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rc.2.24474.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rc.2.24474.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.2.24474.3" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rc.2.24474.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rtm.24508.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rtm.24508.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rtm.24508.4" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rtm.24508.4" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0-preview.9.24507.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
+    <packageSource key="dotnet9">
+      <package pattern="*" />
+    </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />
     </packageSource>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rtm.24509.30",
+    "version": "9.0.100-rtm.24512.1",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rtm.24513.10",
+    "version": "9.0.100-rtm.24514.22",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rtm.24508.22",
+    "version": "9.0.100-rtm.24509.3",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rtm.24512.1",
+    "version": "9.0.100-rtm.24513.10",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rtm.24509.3",
+    "version": "9.0.100-rtm.24509.30",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.2.24474.11",
+    "version": "9.0.100-rtm.24508.22",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <ContainerBaseImage>mcr.microsoft.com/dotnet/nightly/runtime-deps:9.0-preview-noble-chiseled</ContainerBaseImage>
     <ContainerFamily>noble-chiseled</ContainerFamily>
     <ContainerRepository>martincostello/api</ContainerRepository>
     <Description>https://api.martincostello.com/</Description>


### PR DESCRIPTION
Update to the latest nightly build of .NET 9.