### PR TITLE
Avoid running tests

### DIFF
--- a/tests/API.Benchmarks/API.Benchmarks.csproj
+++ b/tests/API.Benchmarks/API.Benchmarks.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Description>Benchmarks for the API.</Description>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <IsTestProject>false</IsTestProject>
     <NoWarn>$(NoWarn);CA2007;CA2234;SA1600</NoWarn>
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Set `IsTestProject=false` to avoid `dotnet test` trying to run tests for the benchmarks project.
