### PR TITLE
Add version endpoint

### DIFF
--- a/src/API/ApplicationJsonSerializerContext.cs
+++ b/src/API/ApplicationJsonSerializerContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using MartinCostello.Api.Models;
 
@@ -11,6 +12,7 @@ namespace MartinCostello.Api;
 [JsonSerializable(typeof(GuidResponse))]
 [JsonSerializable(typeof(HashRequest))]
 [JsonSerializable(typeof(HashResponse))]
+[JsonSerializable(typeof(JsonObject))]
 [JsonSerializable(typeof(MachineKeyResponse))]
 [JsonSerializable(typeof(TimeResponse))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]

--- a/src/API/wwwroot/robots933456.txt
+++ b/src/API/wwwroot/robots933456.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /api
+
+Sitemap: https://api.martincostello.com/sitemap.xml

--- a/tests/API.Tests/EndToEnd/ResourceTests.cs
+++ b/tests/API.Tests/EndToEnd/ResourceTests.cs
@@ -25,6 +25,7 @@ public class ResourceTests(ApiFixture fixture) : EndToEndTest(fixture)
     [InlineData("/humans.txt", MediaTypeNames.Text.Plain)]
     [InlineData("/keybase.txt", MediaTypeNames.Text.Plain)]
     [InlineData("/robots.txt", MediaTypeNames.Text.Plain)]
+    [InlineData("/robots933456.txt", MediaTypeNames.Text.Plain)]
     [InlineData("/sitemap.xml", MediaTypeNames.Text.Xml)]
     [InlineData("/swagger/api/swagger.json", MediaTypeNames.Application.Json)]
     [InlineData("/time", MediaTypeNames.Application.Json)]

--- a/tests/API.Tests/EndToEnd/ResourceTests.cs
+++ b/tests/API.Tests/EndToEnd/ResourceTests.cs
@@ -30,6 +30,7 @@ public class ResourceTests(ApiFixture fixture) : EndToEndTest(fixture)
     [InlineData("/time", MediaTypeNames.Application.Json)]
     [InlineData("/tools/guid", MediaTypeNames.Application.Json)]
     [InlineData("/tools/machinekey?decryptionAlgorithm=3DES&validationAlgorithm=3DES", MediaTypeNames.Application.Json)]
+    [InlineData("/version", MediaTypeNames.Application.Json)]
     public async Task Can_Load_Resource_As_Get(string requestUri, string contentType)
     {
         // Arrange

--- a/tests/API.Tests/Integration/ResourceTests.cs
+++ b/tests/API.Tests/Integration/ResourceTests.cs
@@ -42,6 +42,7 @@ public class ResourceTests(TestServerFixture fixture, ITestOutputHelper outputHe
     [InlineData("/tools/guid?uppercase=false", MediaTypeNames.Application.Json)]
     [InlineData("/tools/guid?uppercase=true", MediaTypeNames.Application.Json)]
     [InlineData("/tools/machinekey?decryptionAlgorithm=3DES&validationAlgorithm=3DES", MediaTypeNames.Application.Json)]
+    [InlineData("/version", MediaTypeNames.Application.Json)]
     public async Task Can_Load_Resource_As_Get(string requestUri, string contentType)
     {
         // Arrange

--- a/tests/API.Tests/Integration/ResourceTests.cs
+++ b/tests/API.Tests/Integration/ResourceTests.cs
@@ -35,6 +35,7 @@ public class ResourceTests(TestServerFixture fixture, ITestOutputHelper outputHe
     [InlineData("/humans.txt", MediaTypeNames.Text.Plain)]
     [InlineData("/keybase.txt", MediaTypeNames.Text.Plain)]
     [InlineData("/robots.txt", MediaTypeNames.Text.Plain)]
+    [InlineData("/robots933456.txt", MediaTypeNames.Text.Plain)]
     [InlineData("/sitemap.xml", MediaTypeNames.Text.Xml)]
     [InlineData("/swagger/api/swagger.json", MediaTypeNames.Application.Json)]
     [InlineData("/time", MediaTypeNames.Application.Json)]


### PR DESCRIPTION
- Add a simple version endpoint that can be used to easily determine where the request from a given domain is being served by/from.
- Add content for `robots933456.txt` to stop 404s from Azure App Service's container readiness checks.
