### PR TITLE
Remove AspNetCoreHostingModel

### DIFF
--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <Description>https://api.martincostello.com/</Description>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>


### PR DESCRIPTION
Property is redundant with move to Linux.
