### PR TITLE
Only label default branch as latest

### DIFF
--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -23,7 +23,8 @@
     <PublishSelfContained>true</PublishSelfContained>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(CI)' == 'true' ">
-    <ContainerImageTags>github-$(GITHUB_RUN_NUMBER);latest</ContainerImageTags>
+    <ContainerImageTags>github-$(GITHUB_RUN_NUMBER)</ContainerImageTags>
+    <ContainerImageTags Condition=" '$(GITHUB_HEAD_REF)' == '' ">$(ContainerImageTags);latest</ContainerImageTags>
     <ContainerRepository>$(GITHUB_REPOSITORY)</ContainerRepository>
     <ContainerTitle>$(GITHUB_REPOSITORY)</ContainerTitle>
     <ContainerVendor>$(GITHUB_REPOSITORY_OWNER)</ContainerVendor>


### PR DESCRIPTION
Do not use the latest tag for any images published in PRs.
