### PR TITLE
Avoid HTTPS redirection warning

### DIFF
--- a/src/API/ApiBuilder.cs
+++ b/src/API/ApiBuilder.cs
@@ -158,8 +158,12 @@ public static class ApiBuilder
 
         if (!app.Environment.IsDevelopment())
         {
-            app.UseHsts()
-               .UseHttpsRedirection();
+            app.UseHsts();
+
+            if (!string.Equals(app.Configuration["ForwardedHeaders_Enabled"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
+            {
+                app.UseHttpsRedirection();
+            }
         }
 
         app.UseResponseCompression();


### PR DESCRIPTION
When deployed with `ForwardedHeaders_Enabled=true` do not enable HTTPS redirection to avoid warnings being logged by platform-level HTTP requests (such as health checks).
