### PR TITLE
Refactor container publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,12 +118,6 @@ jobs:
         ContainerRegistry: ${{ env.PUBLISH_CONTAINER == 'true' && env.CONTAINER_REGISTRY || '' }}
       run: |
         dotnet publish ./src/API --arch x64 --os linux -p:PublishProfile=DefaultContainer
-        if (-Not [string]::IsNullOrWhiteSpace(${env:CONTAINER_REGISTRY})) {
-          $containerImage = "${env:CONTAINER_REGISTRY}/${env:GITHUB_REPOSITORY}".ToLowerInvariant()
-          $containerTag = "${containerImage}:github-${env:GITHUB_RUN_NUMBER}"
-          "container-image=${containerImage}" >> "${env:GITHUB_OUTPUT}"
-          "container-tag=${containerTag}" >> "${env:GITHUB_OUTPUT}"
-        }
 
     - name: Generate SBOM for binaries
       uses: anchore/sbom-action@v0
@@ -133,14 +127,14 @@ jobs:
 
     - name: Generate SBOM for container
       uses: anchore/sbom-action@v0
-      if: env.PUBLISH_CONTAINER == 'true' && steps.publish-container.outputs.container-digest != ''
+      if: steps.publish-container.outputs.container-tag != ''
       with:
         image: ${{ steps.publish-container.outputs.container-tag }}
         output-file: ./artifacts/sbom-container.json
 
     - name: Attest container image
       uses: actions/attest-build-provenance@v1
-      if: env.PUBLISH_CONTAINER == 'true' && steps.publish-container.outputs.container-digest != ''
+      if: steps.publish-container.outputs.container-digest != ''
       with:
         push-to-registry: true
         subject-digest: ${{ steps.publish-container.outputs.container-digest }}
@@ -148,7 +142,7 @@ jobs:
 
     - name: Attest SBOM for container
       uses: actions/attest-sbom@v1
-      if: env.PUBLISH_CONTAINER == 'true' && steps.publish-container.outputs.container-digest != ''
+      if: steps.publish-container.outputs.container-digest != ''
       with:
         push-to-registry: true
         sbom-path: ./artifacts/sbom-container.json

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -52,7 +52,14 @@
       <Content Include="wwwroot/**" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)" />
     </ItemGroup>
   </Target>
-  <Target Name="OutputContainerDigest" AfterTargets="PublishContainer" Condition=" '$(GITHUB_OUTPUT)' != '' ">
+  <Target Name="SetGitHubContainerOutputs" AfterTargets="PublishContainer" Condition=" '$(GITHUB_OUTPUT)' != '' AND '$(ContainerRegistry)' != '' ">
+    <PropertyGroup>
+      <_ContainerImage>$(ContainerRegistry)/$(ContainerRepository)</_ContainerImage>
+      <_ContainerImage>$(_ContainerImage.ToLowerInvariant())</_ContainerImage>
+      <_ContainerTag>$(_ContainerImage):github-$(GITHUB_RUN_NUMBER)</_ContainerTag>
+    </PropertyGroup>
     <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="container-digest=$(GeneratedContainerDigest)" />
+    <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="container-image=$(_ContainerImage)" />
+    <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="container-tag=$(_ContainerTag)" />
   </Target>
 </Project>


### PR DESCRIPTION
Move setting outputs for the container publish to MSBuild target to simplify GitHub Actions workflow.
