### PR TITLE
Switch to Azure Monitor exporter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.6" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.1" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.13.12" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -26,7 +26,7 @@
     <Content Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" />
     <PackageReference Include="NSwag.AspNetCore" />

--- a/src/API/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/API/Extensions/ILoggingBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
+using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 
 namespace MartinCostello.Api.Extensions;
@@ -19,14 +20,19 @@ public static class ILoggingBuilderExtensions
     /// </returns>
     public static ILoggingBuilder AddTelemetry(this ILoggingBuilder builder)
     {
-        return builder.AddOpenTelemetry((p) =>
+        return builder.AddOpenTelemetry((options) =>
         {
-            p.IncludeFormattedMessage = true;
-            p.IncludeScopes = true;
+            options.IncludeFormattedMessage = true;
+            options.IncludeScopes = true;
+
+            if (TelemetryExtensions.IsAzureMonitorConfigured())
+            {
+                options.AddAzureMonitorLogExporter();
+            }
 
             if (TelemetryExtensions.IsOtlpCollectorConfigured())
             {
-                p.AddOtlpExporter();
+                options.AddOtlpExporter();
             }
         });
     }

--- a/src/API/Extensions/TelemetryExtensions.cs
+++ b/src/API/Extensions/TelemetryExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
-using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.ResourceDetectors.Azure;
@@ -28,6 +28,12 @@ public static class TelemetryExtensions
             .AddService(ApplicationTelemetry.ServiceName, serviceVersion: ApplicationTelemetry.ServiceVersion)
             .AddDetector(new AppServiceResourceDetector());
 
+        if (IsAzureMonitorConfigured())
+        {
+            services.Configure<AzureMonitorExporterOptions>(
+                (p) => p.ConnectionString = AzureMonitorConnectionString());
+        }
+
         var telemetry = services
             .AddOpenTelemetry()
             .WithMetrics((builder) =>
@@ -36,6 +42,11 @@ public static class TelemetryExtensions
                        .AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
                        .AddRuntimeInstrumentation();
+
+                if (IsAzureMonitorConfigured())
+                {
+                    builder.AddAzureMonitorMetricExporter();
+                }
 
                 if (IsOtlpCollectorConfigured())
                 {
@@ -54,16 +65,16 @@ public static class TelemetryExtensions
                     builder.SetSampler(new AlwaysOnSampler());
                 }
 
+                if (IsAzureMonitorConfigured())
+                {
+                    builder.AddAzureMonitorTraceExporter();
+                }
+
                 if (IsOtlpCollectorConfigured())
                 {
                     builder.AddOtlpExporter();
                 }
             });
-
-        if (IsAzureMonitorConfigured())
-        {
-            telemetry.UseAzureMonitor();
-        }
 
         services.AddOptions<HttpClientTraceInstrumentationOptions>()
                 .Configure<IServiceProvider>((options, _) => options.RecordException = true);
@@ -76,7 +87,7 @@ public static class TelemetryExtensions
     /// <see langword="true"/> if Azure Monitor is configured; otherwise <see langword="false"/>.
     /// </returns>
     internal static bool IsAzureMonitorConfigured()
-        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING"));
+        => !string.IsNullOrEmpty(AzureMonitorConnectionString());
 
     /// <summary>
     /// Returns whether an OTLP collector is configured.
@@ -86,4 +97,7 @@ public static class TelemetryExtensions
     /// </returns>
     internal static bool IsOtlpCollectorConfigured()
         => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT"));
+
+    private static string? AzureMonitorConnectionString()
+        => Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
 }

--- a/src/API/Extensions/TelemetryExtensions.cs
+++ b/src/API/Extensions/TelemetryExtensions.cs
@@ -34,7 +34,7 @@ public static class TelemetryExtensions
                 (p) => p.ConnectionString = AzureMonitorConnectionString());
         }
 
-        var telemetry = services
+        services
             .AddOpenTelemetry()
             .WithMetrics((builder) =>
             {


### PR DESCRIPTION
Switch to Azure.Monitor.OpenTelemetry.Exporter from Azure.Monitor.OpenTelemetry.AspNetCore as the latter is not AoT friendly (see #1682).
