### PR TITLE
Refactor NSwag usage

### DIFF
--- a/src/API/ApiBuilder.cs
+++ b/src/API/ApiBuilder.cs
@@ -135,11 +135,7 @@ public static class ApiBuilder
             });
         }
 
-        if (RuntimeFeature.IsDynamicCodeSupported)
-        {
-            builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddOpenApiDocumentation();
-        }
+        builder.Services.AddOpenApiDocumentation();
 
         builder.Services.TryAddSingleton(TimeProvider.System);
 

--- a/src/API/ApiModule.cs
+++ b/src/API/ApiModule.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Text.Json.Nodes;
 using MartinCostello.Api.Models;
 using MartinCostello.Api.OpenApi;
+using MartinCostello.Api.OpenApi.NSwag;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using NSwag.Annotations;
@@ -119,6 +120,7 @@ public static class ApiModule
     private static string BytesToHexString(ReadOnlySpan<byte> bytes)
         => Convert.ToHexString(bytes);
 
+    [NSwagOpenApiExample<TimeResponse>]
     [OpenApiExample<TimeResponse>]
     [OpenApiOperation("Gets the current UTC time.", "Gets the current date and time in UTC.")]
     [OpenApiTag("API")]
@@ -140,6 +142,8 @@ public static class ApiModule
         return TypedResults.Ok(result);
     }
 
+    [NSwagOpenApiExample<GuidResponse>]
+    [NSwagOpenApiExample<ProblemDetails, ProblemDetailsExampleProvider>]
     [OpenApiExample<GuidResponse>]
     [OpenApiExample<ProblemDetails, ProblemDetailsExampleProvider>]
     [OpenApiOperation("Generates a GUID.", "Generates a new GUID in the specified format.")]
@@ -148,7 +152,7 @@ public static class ApiModule
     [SwaggerResponse(StatusCodes.Status200OK, typeof(GuidResponse), Description = "A GUID was generated successfully.")]
     [SwaggerResponse(StatusCodes.Status400BadRequest, typeof(ProblemDetails), Description = "The specified format is invalid.")]
     private static Results<Ok<GuidResponse>, ProblemHttpResult> GenerateGuid(
-        [Description("The format for which to generate a GUID.")][OpenApiParameterExample("D")] string? format,
+        [Description("The format for which to generate a GUID.")][OpenApiExample("D")] string? format,
         [Description("Whether to return the GUID in uppercase.")] bool? uppercase)
     {
         string guid;
@@ -170,6 +174,9 @@ public static class ApiModule
         return TypedResults.Ok(new GuidResponse() { Guid = guid });
     }
 
+    [NSwagOpenApiExample<HashRequest>]
+    [NSwagOpenApiExample<HashResponse>]
+    [NSwagOpenApiExample<ProblemDetails, ProblemDetailsExampleProvider>]
     [OpenApiExample<HashRequest>]
     [OpenApiExample<HashResponse>]
     [OpenApiExample<ProblemDetails, ProblemDetailsExampleProvider>]
@@ -246,6 +253,8 @@ public static class ApiModule
         return TypedResults.Ok(result);
     }
 
+    [NSwagOpenApiExample<MachineKeyResponse>]
+    [NSwagOpenApiExample<ProblemDetails, ProblemDetailsExampleProvider>]
     [OpenApiExample<MachineKeyResponse>]
     [OpenApiExample<ProblemDetails, ProblemDetailsExampleProvider>]
     [OpenApiOperation("Generates a machine key.", "Generates a machine key for a Web.config configuration file for ASP.NET.")]
@@ -254,8 +263,8 @@ public static class ApiModule
     [SwaggerResponse(StatusCodes.Status200OK, typeof(MachineKeyResponse), Description = "The machine key was generated successfully.")]
     [SwaggerResponse(StatusCodes.Status400BadRequest, typeof(ProblemDetails), Description = "The specified decryption or validation algorithm is invalid.")]
     private static Results<Ok<MachineKeyResponse>, ProblemHttpResult> GenerateMachineKey(
-        [Description("The name of the decryption algorithm.")][OpenApiParameterExample("AES-256")] string? decryptionAlgorithm,
-        [Description("The name of the validation algorithm.")][OpenApiParameterExample("SHA1")] string? validationAlgorithm)
+        [Description("The name of the decryption algorithm.")][OpenApiExample("AES-256")] string? decryptionAlgorithm,
+        [Description("The name of the validation algorithm.")][OpenApiExample("SHA1")] string? validationAlgorithm)
     {
         if (string.IsNullOrEmpty(decryptionAlgorithm) ||
             !HashSizes.TryGetValue(decryptionAlgorithm + "-D", out int decryptionKeyLength))

--- a/src/API/Extensions/IServiceCollectionExtensions.cs
+++ b/src/API/Extensions/IServiceCollectionExtensions.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
-using MartinCostello.Api.OpenApi;
+using System.Runtime.CompilerServices;
+using MartinCostello.Api.OpenApi.NSwag;
 using MartinCostello.Api.Options;
 using Microsoft.Extensions.Options;
 
@@ -21,6 +22,12 @@ public static class IServiceCollectionExtensions
     /// </returns>
     public static IServiceCollection AddOpenApiDocumentation(this IServiceCollection services)
     {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            return services;
+        }
+
+        services.AddEndpointsApiExplorer();
         services.AddOpenApiDocument((options, services) =>
         {
             var siteOptions = services.GetRequiredService<IOptions<SiteOptions>>().Value;
@@ -51,7 +58,7 @@ public static class IServiceCollectionExtensions
             };
 
             options.OperationProcessors.Add(new RemoveParameterPositionProcessor());
-            options.OperationProcessors.Add(new UpdateProblemDetailsMediaTypeProvider());
+            options.OperationProcessors.Add(new UpdateProblemDetailsMediaTypeProcessor());
             options.SchemaSettings.SchemaProcessors.Add(new RemoveStyleCopPrefixesProcessor());
         });
 

--- a/src/API/Models/GuidResponse.cs
+++ b/src/API/Models/GuidResponse.cs
@@ -22,9 +22,9 @@ public sealed class GuidResponse : IExampleProvider<GuidResponse>
 #pragma warning restore CA1720
 
     /// <inheritdoc/>
-    static object IExampleProvider<GuidResponse>.GenerateExample()
+    static GuidResponse IExampleProvider<GuidResponse>.GenerateExample()
     {
-        return new GuidResponse()
+        return new()
         {
             Guid = new("6bc55a07-3d3e-4d52-8701-362a1187772d"),
         };

--- a/src/API/Models/HashRequest.cs
+++ b/src/API/Models/HashRequest.cs
@@ -38,9 +38,9 @@ public sealed class HashRequest : IExampleProvider<HashRequest>
     public string Plaintext { get; set; } = string.Empty;
 
     /// <inheritdoc/>
-    static object IExampleProvider<HashRequest>.GenerateExample()
+    static HashRequest IExampleProvider<HashRequest>.GenerateExample()
     {
-        return new HashRequest()
+        return new()
         {
             Algorithm = "sha256",
             Format = "base64",

--- a/src/API/Models/HashResponse.cs
+++ b/src/API/Models/HashResponse.cs
@@ -20,9 +20,9 @@ public sealed class HashResponse : IExampleProvider<HashResponse>
     public string Hash { get; set; } = string.Empty;
 
     /// <inheritdoc/>
-    static object IExampleProvider<HashResponse>.GenerateExample()
+    static HashResponse IExampleProvider<HashResponse>.GenerateExample()
     {
-        return new HashResponse()
+        return new()
         {
             Hash = "fTi1zSWiuvha07tbkxE4PmcaihQuswKzJNSl+6h0jGk=",
         };

--- a/src/API/Models/MachineKeyResponse.cs
+++ b/src/API/Models/MachineKeyResponse.cs
@@ -34,9 +34,9 @@ public sealed class MachineKeyResponse : IExampleProvider<MachineKeyResponse>
     public string MachineKeyXml { get; set; } = string.Empty;
 
     /// <inheritdoc/>
-    static object IExampleProvider<MachineKeyResponse>.GenerateExample()
+    static MachineKeyResponse IExampleProvider<MachineKeyResponse>.GenerateExample()
     {
-        return new MachineKeyResponse()
+        return new()
         {
             DecryptionKey = "2EA72C07DEEF522B4686C39BDF83E70A96BA92EE1D960029821FCA2E4CD9FB72",
             ValidationKey = "0A7A92827A74B9B4D2A21918814D8E4A9150BB5ADDB284533BDB50E44ADA6A4BCCFF637A5CB692816EE304121A1BCAA5A6D96BE31A213DEE0BAAEF102A391E8F",

--- a/src/API/Models/TimeResponse.cs
+++ b/src/API/Models/TimeResponse.cs
@@ -48,11 +48,11 @@ public sealed class TimeResponse : IExampleProvider<TimeResponse>
     public string UniversalFull { get; set; } = string.Empty;
 
     /// <inheritdoc/>
-    static object IExampleProvider<TimeResponse>.GenerateExample()
+    static TimeResponse IExampleProvider<TimeResponse>.GenerateExample()
     {
-        return new TimeResponse()
+        return new()
         {
-            Timestamp = new DateTimeOffset(2016, 6, 3, 18, 44, 14, TimeSpan.Zero),
+            Timestamp = new(2016, 6, 3, 18, 44, 14, TimeSpan.Zero),
             Rfc1123 = "Fri, 03 Jun 2016 18:44:14 GMT",
             UniversalFull = "Friday, 03 June 2016 18:44:14",
             UniversalSortable = "2016-06-03 18:44:14Z",

--- a/src/API/OpenApi/IExampleProvider`1.cs
+++ b/src/API/OpenApi/IExampleProvider`1.cs
@@ -9,7 +9,7 @@ namespace MartinCostello.Api.OpenApi;
 /// Defines a method for obtaining examples for OpenAPI documentation.
 /// </summary>
 /// <typeparam name="T">The type of the example.</typeparam>
-public interface IExampleProvider<in T>
+public interface IExampleProvider<T>
 {
     /// <summary>
     /// Generates the example to use.
@@ -17,5 +17,5 @@ public interface IExampleProvider<in T>
     /// <returns>
     /// A <typeparamref name="T"/> that should be used as the example.
     /// </returns>
-    static abstract object GenerateExample();
+    static abstract T GenerateExample();
 }

--- a/src/API/OpenApi/IOpenApiExampleMetadata.cs
+++ b/src/API/OpenApi/IOpenApiExampleMetadata.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Api.OpenApi;
+
+/// <summary>
+/// Defines an OpenAPI example.
+/// </summary>
+public interface IOpenApiExampleMetadata
+{
+    /// <summary>
+    /// Gets the type of the schema associated with the example.
+    /// </summary>
+    Type SchemaType { get; }
+
+    /// <summary>
+    /// Generates an example for the schema.
+    /// </summary>
+    /// <returns>
+    /// The example to use.
+    /// </returns>
+    object GenerateExample();
+}

--- a/src/API/OpenApi/NSwag/NSwagOpenApiExampleAttribute`1.cs
+++ b/src/API/OpenApi/NSwag/NSwagOpenApiExampleAttribute`1.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
-namespace MartinCostello.Api.OpenApi;
+using NSwag.Annotations;
+
+namespace MartinCostello.Api.OpenApi.NSwag;
 
 /// <summary>
-/// An attribute representing an example for an OpenAPI operation parameter.
+/// Defines an attribute for an OpenAPI schema example.
 /// </summary>
 /// <typeparam name="T">The type of the schema.</typeparam>
-public sealed class OpenApiExampleAttribute<T>() : OpenApiExampleAttribute<T, T>()
+public sealed class NSwagOpenApiExampleAttribute<T>() : OpenApiOperationProcessorAttribute(typeof(OpenApiExampleProcessor<T, T>))
     where T : IExampleProvider<T>
 {
 }

--- a/src/API/OpenApi/NSwag/NSwagOpenApiExampleAttribute`2.cs
+++ b/src/API/OpenApi/NSwag/NSwagOpenApiExampleAttribute`2.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+using NSwag.Annotations;
+
+namespace MartinCostello.Api.OpenApi.NSwag;
+
+/// <summary>
+/// Defines an attribute for an OpenAPI schema example.
+/// </summary>
+/// <typeparam name="TSchema">The type of the schema.</typeparam>
+/// <typeparam name="TProvider">The type of the example provider.</typeparam>
+public sealed class NSwagOpenApiExampleAttribute<TSchema, TProvider>() : OpenApiOperationProcessorAttribute(typeof(OpenApiExampleProcessor<TSchema, TProvider>))
+    where TProvider : IExampleProvider<TSchema>
+{
+}

--- a/src/API/OpenApi/NSwag/RemoveParameterPositionProcessor.cs
+++ b/src/API/OpenApi/NSwag/RemoveParameterPositionProcessor.cs
@@ -4,7 +4,7 @@
 using NSwag.Generation.Processors;
 using NSwag.Generation.Processors.Contexts;
 
-namespace MartinCostello.Api.OpenApi;
+namespace MartinCostello.Api.OpenApi.NSwag;
 
 /// <summary>
 /// A class representing a operation processor that removes
@@ -15,7 +15,7 @@ public sealed class RemoveParameterPositionProcessor : IOperationProcessor
     /// <inheritdoc/>
     public bool Process(OperationProcessorContext context)
     {
-        foreach ((_, var parameter) in context.Parameters)
+        foreach (var parameter in context.Parameters.Values)
         {
             parameter.Position = null;
         }

--- a/src/API/OpenApi/NSwag/RemoveStyleCopPrefixesProcessor.cs
+++ b/src/API/OpenApi/NSwag/RemoveStyleCopPrefixesProcessor.cs
@@ -3,7 +3,7 @@
 
 using NJsonSchema.Generation;
 
-namespace MartinCostello.Api.OpenApi;
+namespace MartinCostello.Api.OpenApi.NSwag;
 
 /// <summary>
 /// A class representing a document processor that removes StyleCop
@@ -16,7 +16,7 @@ public sealed class RemoveStyleCopPrefixesProcessor : ISchemaProcessor
     /// <inheritdoc/>
     public void Process(SchemaProcessorContext context)
     {
-        foreach ((_, var property) in context.Schema.ActualProperties)
+        foreach (var property in context.Schema.ActualProperties.Values)
         {
             if (property.Description is not null)
             {

--- a/src/API/OpenApi/NSwag/UpdateProblemDetailsMediaTypeProcessor.cs
+++ b/src/API/OpenApi/NSwag/UpdateProblemDetailsMediaTypeProcessor.cs
@@ -6,13 +6,13 @@ using Microsoft.AspNetCore.Mvc;
 using NSwag.Generation.Processors;
 using NSwag.Generation.Processors.Contexts;
 
-namespace MartinCostello.Api.OpenApi;
+namespace MartinCostello.Api.OpenApi.NSwag;
 
 /// <summary>
 /// A class representing a operation processor that fixes the media type
 /// to use for <see cref="ProblemDetails"/>. This class cannot be inherited.
 /// </summary>
-public sealed class UpdateProblemDetailsMediaTypeProvider : IOperationProcessor
+public sealed class UpdateProblemDetailsMediaTypeProcessor : IOperationProcessor
 {
     /// <inheritdoc/>
     public bool Process(OperationProcessorContext context)

--- a/src/API/OpenApi/OpenApiExampleAttribute.cs
+++ b/src/API/OpenApi/OpenApiExampleAttribute.cs
@@ -8,10 +8,16 @@ namespace MartinCostello.Api.OpenApi;
 /// </summary>
 /// <param name="value">The example value.</param>
 [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
-public sealed class OpenApiParameterExampleAttribute(object value) : Attribute
+public sealed class OpenApiExampleAttribute(string value) : OpenApiExampleAttribute<string, OpenApiExampleAttribute>, IExampleProvider<string>
 {
     /// <summary>
     /// Gets the example value.
     /// </summary>
-    public object Value { get; } = value;
+    public string Value { get; } = value;
+
+    /// <inheritdoc/>
+    static string IExampleProvider<string>.GenerateExample() => "string";
+
+    /// <inheritdoc />
+    public override string GenerateExample() => Value;
 }

--- a/src/API/OpenApi/OpenApiExampleAttribute`2.cs
+++ b/src/API/OpenApi/OpenApiExampleAttribute`2.cs
@@ -1,16 +1,30 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
-using NSwag.Annotations;
-
 namespace MartinCostello.Api.OpenApi;
 
+#pragma warning disable CA1813
+
 /// <summary>
-/// Defines an attribute for an OpenAPI schema example.
+/// An attribute representing an example for an OpenAPI operation parameter.
 /// </summary>
 /// <typeparam name="TSchema">The type of the schema.</typeparam>
 /// <typeparam name="TProvider">The type of the example provider.</typeparam>
-public sealed class OpenApiExampleAttribute<TSchema, TProvider>() : OpenApiOperationProcessorAttribute(typeof(OpenApiExampleProcessor<TSchema, TProvider>))
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter, AllowMultiple = true)]
+public class OpenApiExampleAttribute<TSchema, TProvider> : Attribute, IOpenApiExampleMetadata
     where TProvider : IExampleProvider<TSchema>
 {
+    /// <inheritdoc/>
+    public Type SchemaType => typeof(TSchema);
+
+    /// <summary>
+    /// Generates the example to use.
+    /// </summary>
+    /// <returns>
+    /// A <typeparamref name="TSchema"/> that should be used as the example.
+    /// </returns>
+    public virtual TSchema GenerateExample() => TProvider.GenerateExample();
+
+    /// <inheritdoc/>
+    object IOpenApiExampleMetadata.GenerateExample() => GenerateExample()!;
 }

--- a/src/API/OpenApi/OpenApiResponseAttribute.cs
+++ b/src/API/OpenApi/OpenApiResponseAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Api.OpenApi;
+
+/// <summary>
+/// Represents an OpenAPI operation response.
+/// </summary>
+/// <param name="httpStatusCode">The HTTP status code for the response.</param>
+/// <param name="description">The description of the response.</param>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public sealed class OpenApiResponseAttribute(int httpStatusCode, string description) : Attribute
+{
+    /// <summary>
+    /// Gets the HTTP status code for the response.
+    /// </summary>
+    public int HttpStatusCode { get; } = httpStatusCode;
+
+    /// <summary>
+    /// Gets the description of the response.
+    /// </summary>
+    public string Description { get; } = description;
+}

--- a/src/API/OpenApi/ProblemDetailsExampleProvider.cs
+++ b/src/API/OpenApi/ProblemDetailsExampleProvider.cs
@@ -11,14 +11,14 @@ namespace MartinCostello.Api.OpenApi;
 public sealed class ProblemDetailsExampleProvider : IExampleProvider<ProblemDetails>
 {
     /// <inheritdoc/>
-    public static object GenerateExample()
+    public static ProblemDetails GenerateExample()
     {
-        return new
+        return new()
         {
-            type = "https://tools.ietf.org/html/rfc7231#section-6.5.1",
-            title = "Bad Request",
-            status = StatusCodes.Status400BadRequest,
-            detail = "The specified value is invalid.",
+            Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+            Title = "Bad Request",
+            Status = StatusCodes.Status400BadRequest,
+            Detail = "The specified value is invalid.",
         };
     }
 }


### PR DESCRIPTION
Refactor how NSwag is used to make it easier to adopt OpenAPI in .NET 9.
