### PR TITLE
Suppress IDE0130

### DIFF
--- a/src/API/Extensions/ResultsExtensions.cs
+++ b/src/API/Extensions/ResultsExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Http.HttpResults;
 
+#pragma warning disable IDE0130
 namespace Microsoft.AspNetCore.Http;
 
 /// <summary>


### PR DESCRIPTION
Suppress new IDE0130 warning coming in .NET 9 preview 6.
