### PR TITLE
Fix HTTP 500 serializing errors

### DIFF
--- a/src/API/ApplicationJsonSerializerContext.cs
+++ b/src/API/ApplicationJsonSerializerContext.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using MartinCostello.Api.Models;
+using Microsoft.AspNetCore.Mvc;
 
 namespace MartinCostello.Api;
 
@@ -14,6 +15,7 @@ namespace MartinCostello.Api;
 [JsonSerializable(typeof(HashResponse))]
 [JsonSerializable(typeof(JsonObject))]
 [JsonSerializable(typeof(MachineKeyResponse))]
+[JsonSerializable(typeof(ProblemDetails))]
 [JsonSerializable(typeof(TimeResponse))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
 internal sealed partial class ApplicationJsonSerializerContext : JsonSerializerContext


### PR DESCRIPTION
Fix `ProblemDetails` not being included in the JSON serializer context, which causes an HTTP 500 when attempting to serialize error details when deployed with native AoT.
