### PR TITLE
Update obsolete eslint rule

### DIFF
--- a/src/API/package.json
+++ b/src/API/package.json
@@ -59,11 +59,11 @@
       "@typescript-eslint"
     ],
     "rules": {
+      "@stylistic/js/indent": "error",
       "@stylistic/js/quotes": [
         "error",
         "single"
       ],
-      "@typescript-eslint/indent": "error",
       "@typescript-eslint/member-delimiter-style": "error",
       "@typescript-eslint/naming-convention": "error",
       "@typescript-eslint/prefer-namespace-keyword": "error",


### PR DESCRIPTION
Remove obsolete eslint indentation rule and use recommended replacement.
