### PR TITLE
Use JSON source generator with tests

### DIFF
--- a/.github/workflows/spectral.yml
+++ b/.github/workflows/spectral.yml
@@ -24,4 +24,4 @@ jobs:
       run: npm install -g @stoplight/spectral-cli
 
     - name: Run Spectral
-      run: spectral lint "./src/API/wwwroot/swagger/api/swagger.json" --fail-severity warn --format github-actions
+      run: spectral lint "./src/API/wwwroot/swagger/api/*.json" --fail-severity warn --format github-actions

--- a/src/API/ApplicationJsonSerializerContext.cs
+++ b/src/API/ApplicationJsonSerializerContext.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace MartinCostello.Api;
 
 [ExcludeFromCodeCoverage]
+[JsonSerializable(typeof(bool?))]
 [JsonSerializable(typeof(GuidResponse))]
 [JsonSerializable(typeof(HashRequest))]
 [JsonSerializable(typeof(HashResponse))]
@@ -18,6 +19,6 @@ namespace MartinCostello.Api;
 [JsonSerializable(typeof(ProblemDetails))]
 [JsonSerializable(typeof(TimeResponse))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
-internal sealed partial class ApplicationJsonSerializerContext : JsonSerializerContext
+public sealed partial class ApplicationJsonSerializerContext : JsonSerializerContext
 {
 }

--- a/tests/API.Tests/API.Tests.csproj
+++ b/tests/API.Tests/API.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <Description>Tests for https://api.martincostello.com/</Description>
     <IsTestProject>true</IsTestProject>
+    <!-- HACK Disable with ASP.NET Core 9 preview 7 -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     <NoWarn>$(NoWarn);CA1707;CA1711;CA2007;CA2234;SA1600</NoWarn>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.Api</RootNamespace>
@@ -39,6 +41,6 @@
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[xunit.*]*</Exclude>
     <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
-    <Threshold>63</Threshold>
+    <Threshold>70,45,70</Threshold>
   </PropertyGroup>
 </Project>

--- a/tests/API.Tests/EndToEnd/ApiTests.cs
+++ b/tests/API.Tests/EndToEnd/ApiTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.WebUtilities;
 
@@ -94,11 +95,11 @@ public class ApiTests(ApiFixture fixture) : EndToEndTest(fixture)
     public async Task Can_Generate_Hash(string algorithm, string format, string plaintext, string expected)
     {
         // Arrange
-        var request = new
+        var request = new JsonObject()
         {
-            algorithm,
-            format,
-            plaintext,
+            ["algorithm"] = algorithm,
+            ["format"] = format,
+            ["plaintext"] = plaintext,
         };
 
         using var client = Fixture.CreateClient();

--- a/tests/API.Tests/Integration/OpenApiTests.cs
+++ b/tests/API.Tests/Integration/OpenApiTests.cs
@@ -11,12 +11,12 @@ namespace MartinCostello.Api.Integration;
 [Collection(TestServerCollection.Name)]
 public class OpenApiTests(TestServerFixture fixture, ITestOutputHelper outputHelper) : IntegrationTest(fixture, outputHelper)
 {
-    [Fact]
-    public async Task Static_And_Dynamic_Schema_Should_Match()
+    [Theory]
+    [InlineData("/swagger/api/swagger.json")]
+    public async Task Static_And_Dynamic_Schema_Should_Match(string subpath)
     {
         // Arrange
-        var requestUri = new Uri("/swagger/api/swagger.json", UriKind.Relative);
-        string subpath = "swagger/api/swagger.json";
+        var requestUri = new Uri(subpath, UriKind.Relative);
 
         var environment = Fixture.Services.GetRequiredService<IWebHostEnvironment>();
 

--- a/tests/API.Tests/Integration/TimeTests.cs
+++ b/tests/API.Tests/Integration/TimeTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
 using System.Net.Http.Json;
-using MartinCostello.Api.Models;
 
 namespace MartinCostello.Api.Integration;
 
@@ -24,7 +23,7 @@ public class TimeTests(TestServerFixture fixture, ITestOutputHelper outputHelper
         using var client = Fixture.CreateClient();
 
         // Act
-        var actual = await client.GetFromJsonAsync<TimeResponse>("/time");
+        var actual = await client.GetFromJsonAsync("/time", ApplicationJsonSerializerContext.Default.TimeResponse);
 
         // Assert
         actual.ShouldNotBeNull();

--- a/tests/API.Tests/Integration/ToolsTests.cs
+++ b/tests/API.Tests/Integration/ToolsTests.cs
@@ -48,12 +48,12 @@ public class ToolsTests(TestServerFixture fixture, ITestOutputHelper outputHelpe
         using var client = Fixture.CreateClient();
 
         // Act
-        using var response = await client.PostAsJsonAsync("/tools/hash", request);
+        using var response = await client.PostAsJsonAsync("/tools/hash", request, ApplicationJsonSerializerContext.Default.HashRequest);
 
         // Assert
         response.EnsureSuccessStatusCode();
 
-        var actual = await response.Content.ReadFromJsonAsync<HashResponse>();
+        var actual = await response.Content.ReadFromJsonAsync(ApplicationJsonSerializerContext.Default.HashResponse);
 
         actual.ShouldNotBeNull();
         actual.Hash.ShouldBe(expected);
@@ -66,8 +66,9 @@ public class ToolsTests(TestServerFixture fixture, ITestOutputHelper outputHelpe
         using var client = Fixture.CreateClient();
 
         // Act
-        var actual = await client.GetFromJsonAsync<MachineKeyResponse>(
-            "/tools/machinekey?decryptionAlgorithm=AES-256&validationAlgorithm=SHA1");
+        var actual = await client.GetFromJsonAsync(
+            "/tools/machinekey?decryptionAlgorithm=AES-256&validationAlgorithm=SHA1",
+            ApplicationJsonSerializerContext.Default.MachineKeyResponse);
 
         // Assert
         actual.ShouldNotBeNull();
@@ -139,7 +140,7 @@ public class ToolsTests(TestServerFixture fixture, ITestOutputHelper outputHelpe
         using var client = Fixture.CreateClient();
 
         // Act
-        using var response = await client.PostAsJsonAsync("/tools/hash", request);
+        using var response = await client.PostAsJsonAsync("/tools/hash", request, ApplicationJsonSerializerContext.Default.HashRequest);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);


### PR DESCRIPTION
- Use the JSON source generator in tests to validate AoT behaviour.
- Support `bool?` in the JSON source generator for use with .NET 9 OpenAPI library.
- Analyse any OpenAPI documents in `swagger/api`.

Cherry-picked from #1503 and #1504.
