### PR TITLE
Handle CLI OpenAPI generation

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,4 +1,1 @@
 extends: ['spectral:oas']
-
-rules:
-  operation-tag-defined: off    

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -13,6 +13,7 @@
     <PublishSelfContained>true</PublishSelfContained>
     <RootNamespace>MartinCostello.Api</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <Summary>Martin Costello's API</Summary>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>

--- a/src/API/OpenApi/AddServers.cs
+++ b/src/API/OpenApi/AddServers.cs
@@ -24,7 +24,12 @@ internal sealed class AddServers(
 
     private static string GetServerUrl(IHttpContextAccessor accessor, ForwardedHeadersOptions options)
     {
-        var request = accessor.HttpContext!.Request;
+        var request = accessor.HttpContext?.Request;
+
+        if (request is null)
+        {
+            return "https://api.martincostello.com";
+        }
 
         string scheme = TryGetFirstHeader(options.ForwardedProtoHeaderName) ?? request.Scheme;
         string host = TryGetFirstHeader(options.ForwardedHostHeaderName) ?? request.Host.ToString();


### PR DESCRIPTION
- Update `AddServers` to handle invocation outside of an HTTP request, e.g. when generating the OpenAPI document using the MSBuild support.
- Remove spectral rule override for operation tags as they are now present.
- Disable `TrimmerSingleWarn` so that all trim warnings, if any, are shown.
