### PR TITLE
Add continuous benchmarks

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -9,8 +9,7 @@ env:
 
 on:
   push:
-    # TODO Remove once tested
-    branches: [ main, continuous-benchmarks ]
+    branches: [ main ]
     paths-ignore:
       - '**/*.gitattributes'
       - '**/*.gitignore'

--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -46,12 +46,12 @@ jobs:
       shell: pwsh
       run: ./benchmark.ps1
 
-    - name: Publish benchmark results
+    - name: Publish results
       uses: benchmark-action/github-action-benchmark@v1
       with:
         auto-push: true
         alert-comment-cc-users: '@${{ github.repository_owner }}'
-        benchmark-data-dir-path: ''
+        benchmark-data-dir-path: 'api'
         comment-on-alert: true
         fail-on-alert: true
         gh-pages-branch: main

--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -1,0 +1,62 @@
+name: benchmark-ci
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  NUGET_XMLDOC_MODE: skip
+  TERM: xterm
+
+on:
+  push:
+    # TODO Remove once tested
+    branches: [ main, continuous-benchmarks ]
+    paths-ignore:
+      - '**/*.gitattributes'
+      - '**/*.gitignore'
+      - '**/*.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: benchmark
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: false
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Run benchmarks
+      shell: pwsh
+      run: ./benchmark.ps1
+
+    - name: Publish benchmark results
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        auto-push: true
+        alert-comment-cc-users: '@${{ github.repository_owner }}'
+        benchmark-data-dir-path: ''
+        comment-on-alert: true
+        fail-on-alert: true
+        gh-pages-branch: main
+        gh-repository: 'github.com/${{ github.repository_owner }}/benchmarks'
+        github-token: ${{ secrets.BENCHMARKS_SECRET }}
+        name: API Benchmarks
+        output-file-path: tests/API.Benchmarks/BenchmarkDotNet.Artifacts/results/MartinCostello.Api.Benchmarks.ApiBenchmarks-report-full-compressed.json
+        tool: 'benchmarkdotnet'

--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -4,9 +4,12 @@
 #Requires -Version 7
 
 param(
+    [Parameter(Mandatory = $false)][string] $Filter = "",
+    [Parameter(Mandatory = $false)][string] $Job = ""
 )
 
 $ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
 
 if ($null -eq $env:MSBUILDTERMINALLOGGER) {
     $env:MSBUILDTERMINALLOGGER = "auto"
@@ -62,4 +65,21 @@ $benchmarks = (Join-Path $solutionPath "tests" "API.Benchmarks" "API.Benchmarks.
 
 Write-Host "Running benchmarks..." -ForegroundColor Green
 
-& $dotnet run --project $benchmarks --configuration "Release" -- --filter '*'
+$additionalArgs = @()
+
+if (-Not [string]::IsNullOrEmpty($Filter)) {
+    $additionalArgs += "--filter"
+    $additionalArgs += $Filter
+}
+
+if (-Not [string]::IsNullOrEmpty($Job)) {
+    $additionalArgs += "--job"
+    $additionalArgs += $Job
+}
+
+if (-Not [string]::IsNullOrEmpty(${env:GITHUB_SHA})) {
+    $additionalArgs += "--exporters"
+    $additionalArgs += "json"
+}
+
+& $dotnet run --project $benchmarks --configuration "Release" -- $additionalArgs

--- a/tests/API.Benchmarks/Properties/launchSettings.json
+++ b/tests/API.Benchmarks/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "API.Benchmarks": {
       "commandName": "Project",
-      "commandLineArgs": "--test"
+      "commandLineArgs": ""
     }
   }
 }


### PR DESCRIPTION
Add GitHub Actions workflow to run continuous benchmarks for commits to main and publish to [a tracking website](https://github.com/martincostello/benchmarks).
