### PR TITLE
Remove web SDK from benchmarks

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -65,10 +65,7 @@ $benchmarks = (Join-Path $solutionPath "tests" "API.Benchmarks" "API.Benchmarks.
 
 Write-Host "Running benchmarks..." -ForegroundColor Green
 
-$additionalArgs = @(
-    "--artifacts",
-    (Join-Path $solutionPath "BenchmarkDotNet.Artifacts")
-)
+$additionalArgs = @()
 
 if (-Not [string]::IsNullOrEmpty($Filter)) {
     $additionalArgs += "--filter"

--- a/tests/API.Benchmarks/API.Benchmarks.csproj
+++ b/tests/API.Benchmarks/API.Benchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Benchmarks for the API.</Description>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/tests/API.Benchmarks/ApiBenchmarks.cs
+++ b/tests/API.Benchmarks/ApiBenchmarks.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
+using System.Net.Http.Json;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnosers;
 

--- a/tests/API.Benchmarks/ApiServer.cs
+++ b/tests/API.Benchmarks/ApiServer.cs
@@ -1,8 +1,12 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace MartinCostello.Api.Benchmarks;
 


### PR DESCRIPTION
Remove the web SDK from the benchmarks project so that the artifact directory is not overridden.
