### PR TITLE
Update condition

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
     if: |
       github.event.repository.fork == false &&
       github.event.issue.pull_request != '' &&
-      contains(github.event.comment.body, '/benchmark')
+      startsWith(github.event.comment.body, '/benchmark')
 
     steps:
 


### PR DESCRIPTION
Use `startsWith()` to avoid rogue runs (see https://github.com/martincostello/api/pull/1933#issuecomment-2295308909).
