### PR TITLE
Fix workflow warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,6 @@ jobs:
     - uses: codecov/codecov-action@v5
       name: Upload coverage to Codecov
       with:
-        file: ./artifacts/coverage/coverage.cobertura.xml
         flags: ${{ matrix.os-name }}
         token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Remove deprecated `file` input for codecov/codecov-action.
