### PR TITLE
Avoid Uri allocations

### DIFF
--- a/src/API/Extensions/HttpRequestExtensions.cs
+++ b/src/API/Extensions/HttpRequestExtensions.cs
@@ -64,8 +64,7 @@ public static class HttpRequestExtensions
             return string.Empty;
         }
 
-        // Azure Blob storage is case-sensitive, so force all URLs to lowercase
-        return value.ToAbsolute(cdn.Host, contentPath.ToLowerInvariant());
+        return $"{cdn}{value.Content(contentPath)}";
     }
 
     /// <summary>
@@ -102,7 +101,4 @@ public static class HttpRequestExtensions
 
         return result;
     }
-
-    private static string ToAbsolute(this HttpRequest request, string host, string contentPath)
-        => new Uri(new Uri(request.Scheme + "://" + host), request.Content(contentPath)).ToString();
 }

--- a/src/API/Slices/_Layout.cshtml
+++ b/src/API/Slices/_Layout.cshtml
@@ -14,7 +14,7 @@
 <html lang="en-gb">
 <head prefix="og:http://ogp.me/ns#">
     @(await RenderPartialAsync<_Meta, MetaModel>(meta))
-    @(await RenderPartialAsync<_Links>())
+    @(await RenderPartialAsync<_Links, string?>(meta.CanonicalUri))
     @await RenderSectionAsync("links")
     @await RenderSectionAsync("styles")
     <script type="text/javascript">

--- a/src/API/Slices/_Links.cshtml
+++ b/src/API/Slices/_Links.cshtml
@@ -1,9 +1,9 @@
+@inherits RazorSlice<string?>
 @{
     var options = Options.Value;
     var request = HttpContext!.Request;
-    var canonical = request.Canonical();
 }
-<link rel="canonical" href="@(canonical)" />
+<link rel="canonical" href="@(Model)" />
 <link rel="manifest" href="@(request.Content("~/manifest.webmanifest"))" />
 <link rel="sitemap" type="application/xml" href="@(request.Content("~/sitemap.xml"))" />
 <link rel="shortcut icon" type="image/x-icon" href="@(request.CdnContent("favicon.ico", options))" />


### PR DESCRIPTION
- Construct CDN URLs with strings to avoid `Uri` allocations.
- Only compute the canonical URL once per request.
