### PR TITLE
Add Proscope-k6 middleware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         PYROSCOPE_ARCH: 'x86_64'
         PYROSCOPE_VARIANT: 'glibc'
         PYROSCOPE_VERSION: '0.9.4'
-        UsePyroscope: 'false'
+        UsePyroscope: 'true'
       run: |
         if (${env:UsePyroscope} -eq "true") {
           Write-Output "Downloading Pyroscope..."

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
@@ -31,6 +30,7 @@
     <PackageVersion Include="OpenTelemetry.Resources.Container" Version="1.10.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.11.0-beta.2" />
     <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.11.0-beta.2" />
+    <PackageVersion Include="Pyroscope" Version="0.9.4" />
     <PackageVersion Include="Pyroscope.OpenTelemetry" Version="0.2.0" />
     <PackageVersion Include="RazorSlices" Version="0.9.1" />
     <PackageVersion Include="ReportGenerator" Version="5.4.4" />

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -25,7 +25,6 @@
     <PyroscopeLabels Include="api" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="MartinCostello.OpenApi.Extensions" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
@@ -42,6 +41,7 @@
     <PackageReference Include="OpenTelemetry.Resources.Container" />
     <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" />
     <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" />
+    <PackageReference Include="Pyroscope" />
     <PackageReference Include="Pyroscope.OpenTelemetry" />
     <PackageReference Include="RazorSlices" />
   </ItemGroup>

--- a/src/API/ApiBuilder.cs
+++ b/src/API/ApiBuilder.cs
@@ -148,6 +148,11 @@ public static class ApiBuilder
 
         var app = builder.Build();
 
+        if (TelemetryExtensions.IsPyroscopeConfigured())
+        {
+            app.UseMiddleware<PyroscopeK6Middleware>();
+        }
+
         app.UseMiddleware<CustomHttpHeadersMiddleware>();
 
         if (!app.Environment.IsDevelopment())

--- a/src/API/Extensions/ILoggingBuilderExtensions.cs
+++ b/src/API/Extensions/ILoggingBuilderExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for full license information.
 
-using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 
 namespace MartinCostello.Api.Extensions;
@@ -26,11 +25,6 @@ public static class ILoggingBuilderExtensions
             options.IncludeScopes = true;
 
             options.SetResourceBuilder(TelemetryExtensions.ResourceBuilder);
-
-            if (TelemetryExtensions.IsAzureMonitorConfigured())
-            {
-                options.AddAzureMonitorLogExporter();
-            }
 
             if (TelemetryExtensions.IsOtlpCollectorConfigured())
             {

--- a/src/API/Middleware/PyroscopeK6Middleware.cs
+++ b/src/API/Middleware/PyroscopeK6Middleware.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+//// Based on https://github.com/grafana/pyroscope-go/blob/8fff2bccb5ed5611fdb09fdbd9a727367ab35f39/x/k6/baggage.go
+
+using System.Diagnostics;
+using Pyroscope;
+
+namespace MartinCostello.Api.Middleware;
+
+/// <summary>
+/// A class representing middleware for adding profiler labels for Pyroscope from k6. This class cannot be inherited.
+/// </summary>
+internal sealed class PyroscopeK6Middleware(RequestDelegate next)
+{
+    private readonly RequestDelegate _next = next;
+
+    /// <summary>
+    /// Invokes the middleware asynchronously.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <returns>
+    /// A <see cref="Task"/> representing the actions performed by the middleware.
+    /// </returns>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (ExtractK6Baggage() is { Count: > 0 } baggage)
+        {
+            try
+            {
+                foreach ((string key, string value) in baggage)
+                {
+                    Profiler.Instance.SetDynamicTag(key, value);
+                }
+
+                await _next(context).ConfigureAwait(false);
+            }
+            finally
+            {
+                Profiler.Instance.ClearDynamicTags();
+            }
+        }
+        else
+        {
+            await _next(context).ConfigureAwait(false);
+        }
+    }
+
+    private static Dictionary<string, string>? ExtractK6Baggage()
+    {
+        if (Activity.Current is not { } activity ||
+            activity.Baggage is not { } baggage)
+        {
+            return null;
+        }
+
+        Dictionary<string, string>? labels = null;
+
+        foreach ((string key, string? value) in baggage.Where((p) => p.Key.StartsWith("k6.", StringComparison.Ordinal)))
+        {
+            if (value is { Length: > 0 })
+            {
+                string label = key.Replace('.', '_');
+
+                labels ??= [];
+                labels[key] = value;
+            }
+        }
+
+        return labels;
+    }
+}

--- a/src/API/Middleware/PyroscopeK6Middleware.cs
+++ b/src/API/Middleware/PyroscopeK6Middleware.cs
@@ -63,7 +63,7 @@ internal sealed class PyroscopeK6Middleware(RequestDelegate next)
                 string label = key.Replace('.', '_');
 
                 labels ??= [];
-                labels[key] = value;
+                labels[label] = value;
             }
         }
 

--- a/tests/API.Tests/API.Tests.csproj
+++ b/tests/API.Tests/API.Tests.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   <PropertyGroup>
     <CollectCoverage Condition=" '$(WEBSITE_URL)' == '' ">true</CollectCoverage>
-    <Threshold>85,60,75</Threshold>
+    <Threshold>85,59,90</Threshold>
   </PropertyGroup>
   <ItemGroup>
     <CoverletExclude Include="$([MSBuild]::Escape('[MartinCostello.OpenApi.Extensions]*'))" />


### PR DESCRIPTION
- Add middleware to label profiles with k6 baggage.
- Re-enable Pyroscope to try it out.
- Remove Azure Monitor.