### PR TITLE
Right-size labels collection

### DIFF
--- a/src/API/Middleware/PyroscopeK6Middleware.cs
+++ b/src/API/Middleware/PyroscopeK6Middleware.cs
@@ -62,7 +62,8 @@ internal sealed class PyroscopeK6Middleware(RequestDelegate next)
             {
                 string label = key.Replace('.', '_');
 
-                labels ??= [];
+                // See https://github.com/grafana/jslib.k6.io/blob/80255ea7b239d3d4a8cd4e82192eef4ba27941a2/lib/http-instrumentation-pyroscope/1.0.1/index.js#L11
+                labels ??= new(3);
                 labels[label] = value;
             }
         }

--- a/src/API/Middleware/PyroscopeK6Middleware.cs
+++ b/src/API/Middleware/PyroscopeK6Middleware.cs
@@ -28,6 +28,8 @@ internal sealed class PyroscopeK6Middleware(RequestDelegate next)
         {
             try
             {
+                Profiler.Instance.ClearDynamicTags();
+
                 foreach ((string key, string value) in baggage)
                 {
                     Profiler.Instance.SetDynamicTag(key, value);


### PR DESCRIPTION
- k6 should send 3 pieces of baggage, so allocate the dictionary's capacity to 3.
- Clear the dynamic tags before setting them.
