### PR TITLE
Set JsonNumberHandling.Strict

### DIFF
--- a/src/API/ApiBuilder.cs
+++ b/src/API/ApiBuilder.cs
@@ -74,6 +74,7 @@ public static class ApiBuilder
 
         builder.Services.ConfigureHttpJsonOptions((options) =>
         {
+            options.SerializerOptions.NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.Strict;
             options.SerializerOptions.PropertyNameCaseInsensitive = false;
             options.SerializerOptions.WriteIndented = true;
             options.SerializerOptions.TypeInfoResolverChain.Insert(0, ApplicationJsonSerializerContext.Default);

--- a/src/API/ApplicationJsonSerializerContext.cs
+++ b/src/API/ApplicationJsonSerializerContext.cs
@@ -20,5 +20,9 @@ namespace MartinCostello.Api;
 [JsonSerializable(typeof(MachineKeyResponse))]
 [JsonSerializable(typeof(ProblemDetails))]
 [JsonSerializable(typeof(TimeResponse))]
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSourceGenerationOptions(
+    NumberHandling = JsonNumberHandling.Strict,
+    PropertyNameCaseInsensitive = false,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true)]
 public sealed partial class ApplicationJsonSerializerContext : JsonSerializerContext;


### PR DESCRIPTION
Set `JsonNumberHandling.Strict` for JSON serialization to avoid behaviour change with OpenAPI in .NET 10.
