### PR TITLE
Install libnghttp2-dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,8 @@ jobs:
 
     # HACK Workaround https://github.com/getsentry/sentry-dotnet/issues/4116
     - name: Install native dependencies for Sentry
-      shell: bash
       if: runner.os == 'Linux'
+      shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install --yes --no-install-recommends libcurl4-openssl-dev libz-dev
@@ -135,6 +135,14 @@ jobs:
         registry: ${{ env.CONTAINER_REGISTRY }}
         username: ${{ secrets.ACR_REGISTRY_USERNAME }}
         password: ${{ secrets.ACR_REGISTRY_PASSWORD }}
+
+    # HACK Workaround https://github.com/getsentry/sentry-dotnet/issues/4116
+    - name: Install native container runtime dependencies for Sentry
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends nghttp2
 
     - name: Publish container
       id: publish-container

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install --yes --no-install-recommends nghttp2
+        sudo apt-get install --yes --no-install-recommends libnghttp2-dev
 
     - name: Publish container
       id: publish-container


### PR DESCRIPTION
Install `nghttp2` so that `libnghttp2` is present on the container to be copied into the container image for use with Sentry native.
