### PR TITLE
Install libidn2-dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install --yes --no-install-recommends libnghttp2-dev
+        sudo apt-get install --yes --no-install-recommends libidn2-dev libnghttp2-dev
 
     - name: Publish container
       id: publish-container

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -77,6 +77,7 @@
     <Error Condition="!Exists('$(libcurlBinariesPath)')" Text="Cannot find the libcurl binaries directory '$(libcurlBinariesPath)'." />
     <ItemGroup>
       <Content Include="$(libcurlBinariesPath)\**\libcurl*" CopyToPublishDirectory="PreserveNewest" />
+      <Content Include="$(libcurlBinariesPath)\**\libidn2*" CopyToPublishDirectory="PreserveNewest" />
       <Content Include="$(libcurlBinariesPath)\**\libnghttp2*" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Install `libidn2-dev` to make `libidn2` available to the container.
