### PR TITLE
Remove Sentry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,14 +74,6 @@ jobs:
           "NUGET_PACKAGES=$nugetHome" >> ${env:GITHUB_ENV}
         }
 
-    # HACK Workaround https://github.com/getsentry/sentry-dotnet/issues/4116
-    - name: Install native dependencies for Sentry
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install --yes --no-install-recommends libcurl4-openssl-dev libz-dev
-
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
@@ -136,14 +128,6 @@ jobs:
         username: ${{ secrets.ACR_REGISTRY_USERNAME }}
         password: ${{ secrets.ACR_REGISTRY_PASSWORD }}
 
-    # HACK Workaround https://github.com/getsentry/sentry-dotnet/issues/4116
-    - name: Install native container runtime dependencies for Sentry
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install --yes --no-install-recommends libgnutls28-dev libidn2-dev libnghttp2-dev librtmp-dev libunistring-dev
-
     - name: Publish container
       id: publish-container
       if: runner.os == 'Linux'
@@ -154,7 +138,6 @@ jobs:
         PYROSCOPE_ARCH: 'x86_64'
         PYROSCOPE_VARIANT: 'glibc'
         PYROSCOPE_VERSION: '0.9.4'
-        SentryAuthToken: ${{ secrets.SENTRY_TOKEN }}
         UsePyroscope: 'false'
       run: |
         if (${env:UsePyroscope} -eq "true") {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,6 @@
     <PackageVersion Include="Pyroscope.OpenTelemetry" Version="0.2.0" />
     <PackageVersion Include="RazorSlices" Version="0.9.1" />
     <PackageVersion Include="ReportGenerator" Version="5.4.5" />
-    <PackageVersion Include="Sentry.AspNetCore" Version="5.5.1" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Verify.XunitV3" Version="29.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />

--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -44,7 +44,6 @@
     <PackageReference Include="Pyroscope" />
     <PackageReference Include="Pyroscope.OpenTelemetry" />
     <PackageReference Include="RazorSlices" />
-    <PackageReference Include="Sentry.AspNetCore" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="coverage\**;package.json;package-lock.json;tsconfig.json" CopyToPublishDirectory="Never" />
@@ -65,28 +64,4 @@
   <PropertyGroup Condition=" '$(UsePyroscope)' == 'true' ">
     <PublishAot>false</PublishAot>
   </PropertyGroup>
-  <!-- HACK Workaround for https://github.com/getsentry/sentry-dotnet/issues/3928 -->
-  <ItemGroup Condition=" $([System.OperatingSystem]::IsWindows()) ">
-    <LinkerArg Include="/NODEFAULTLIB:MSVCRT" />
-  </ItemGroup>
-  <!-- HACK Workaround https://github.com/getsentry/sentry-dotnet/issues/4116 by adding the native binaries for Sentry to the container -->
-  <Target Name="_AddSentryNativeBinaries" BeforeTargets="AssignTargetPaths" Condition="$([System.OperatingSystem]::IsLinux())">
-    <PropertyGroup>
-      <libcurlBinariesPath>/usr/lib/x86_64-linux-gnu</libcurlBinariesPath>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(libcurlBinariesPath)')" Text="Cannot find the native binaries directory '$(libcurlBinariesPath)'." />
-    <ItemGroup>
-      <Content Include="$(libcurlBinariesPath)\**\libcurl*" CopyToPublishDirectory="PreserveNewest" />
-      <Content Include="$(libcurlBinariesPath)\**\libgnutls*" CopyToPublishDirectory="PreserveNewest" />
-      <Content Include="$(libcurlBinariesPath)\**\libidn2*" CopyToPublishDirectory="PreserveNewest" />
-      <Content Include="$(libcurlBinariesPath)\**\libnghttp2*" CopyToPublishDirectory="PreserveNewest" />
-      <Content Include="$(libcurlBinariesPath)\**\librtmp*" CopyToPublishDirectory="PreserveNewest" />
-      <Content Include="$(libcurlBinariesPath)\**\libunistring*" CopyToPublishDirectory="PreserveNewest" />
-    </ItemGroup>
-  </Target>
-  <Target Name="_ConfigureSentryNative" BeforeTargets="PublishContainer" DependsOnTargets="ComputeContainerConfig" Condition="$([System.OperatingSystem]::IsLinux())">
-    <ItemGroup>
-      <ContainerEnvironmentVariables Include="LD_PRELOAD" Value="$(ContainerWorkingDirectory)libnghttp2.so $(ContainerWorkingDirectory)libidn2.so $(ContainerWorkingDirectory)libunistring.so $(ContainerWorkingDirectory)librtmp.so $(ContainerWorkingDirectory)libgnutls.so" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/API/ApiBuilder.cs
+++ b/src/API/ApiBuilder.cs
@@ -147,11 +147,6 @@ public static class ApiBuilder
         builder.WebHost.CaptureStartupErrors(true);
         builder.WebHost.ConfigureKestrel((p) => p.AddServerHeader = false);
 
-        if (builder.Configuration["Sentry:Dsn"] is { Length: > 0 } dsn)
-        {
-            builder.WebHost.UseSentry(dsn);
-        }
-
         var app = builder.Build();
 
         if (ApplicationTelemetry.IsPyroscopeConfigured())


### PR DESCRIPTION
It's too much work trying to work out all the `.so` files needed to deploy to the chiseled container, so just remove until Sentry native can be opted-out of.
