### PR TITLE
Disable Sentry native

### DIFF
--- a/src/API/API.csproj
+++ b/src/API/API.csproj
@@ -14,6 +14,8 @@
     <PublishAot>true</PublishAot>
     <PublishSelfContained>true</PublishSelfContained>
     <RootNamespace>MartinCostello.Api</RootNamespace>
+    <!-- HACK Workaround for https://github.com/getsentry/sentry-dotnet/issues/4296 -->
+    <SentryNative>false</SentryNative>
     <TargetFramework>net9.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>


### PR DESCRIPTION
5.11.0 seems to have regressed automatic disabling.