### PR TITLE
Enable HTTP 1.1 and 2

### DIFF
--- a/src/API/appsettings.json
+++ b/src/API/appsettings.json
@@ -1,4 +1,9 @@
 {
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http1AndHttp2"
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Enable Kestrel to respond to HTTP 1.1 and HTTP/2.

Hopefully this fixes gRPC not working in Azure App Service.
