### PR TITLE
Update OpenTelemetry packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,10 +25,10 @@
     <PackageVersion Include="Microsoft.OpenApi" Version="2.3.8" />
     <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="2.3.8" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.9.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.13.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0-rc.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0-rc.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0-rc.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0-rc.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.13.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.13.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Container" Version="1.13.0-beta.1" />


### PR DESCRIPTION
Update to 1.14.0-rc.1 prerelease that has native support for .NET 10.
