### PR TITLE
Update NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.3.9" />
     <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="2.3.9" />
@@ -29,12 +29,12 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.13.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.13.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Resources.Container" Version="1.13.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Resources.Host" Version="1.13.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.13.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.13.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.14.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.14.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.Container" Version="1.14.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.Host" Version="1.14.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.14.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.14.0-beta.1" />
     <PackageVersion Include="Pyroscope" Version="0.13.0" />
     <PackageVersion Include="Pyroscope.OpenTelemetry" Version="0.3.0" />
     <PackageVersion Include="RazorSlices" Version="0.9.5" />


### PR DESCRIPTION
- Update OpenTelemetry packages to their latest versions.
- Update Microsoft.Extensions.TimeProvider.Testing to 10.0.0.
