### PR TITLE
Disable Sentry HTTP message handler

### DIFF
--- a/src/API/ApiBuilder.cs
+++ b/src/API/ApiBuilder.cs
@@ -165,7 +165,11 @@ public static class ApiBuilder
 
         if (builder.Configuration["Sentry:Dsn"] is { Length: > 0 } dsn)
         {
-            builder.WebHost.UseSentry(dsn);
+            builder.WebHost.UseSentry((options) =>
+            {
+                options.DisableSentryHttpMessageHandler = true;
+                options.Dsn = dsn;
+            });
         }
 
         var app = builder.Build();


### PR DESCRIPTION
Sentry recommends disabling it when OpenTelemetry.Instrumentation.Http is used.
