### PR TITLE
Fix Pyroscope

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,21 +136,25 @@ jobs:
         PYROSCOPE_ARCH: 'x86_64'
         PYROSCOPE_VARIANT: 'glibc'
         # renovate: datasource=nuget depName=Pyroscope packageName=Pyroscope
-        PYROSCOPE_VERSION: '0.15.0'
+        PYROSCOPE_VERSION: '1.3.0'
         SentryAuthToken: ${{ secrets.SENTRY_TOKEN }}
         UsePyroscope: 'false'
       run: |
         if (${env:UsePyroscope} -eq "true") {
-          Write-Output "Downloading Pyroscope..."
-
-          $pyroscope = (gh api "/repos/grafana/pyroscope-dotnet/releases/tags/v${env:PYROSCOPE_VERSION}-pyroscope" | ConvertFrom-Json)
-          $pyroscopeAsset = $pyroscope.assets | Where-Object { $_.name -eq "pyroscope.${env:PYROSCOPE_VERSION}-${env:PYROSCOPE_VARIANT}-${env:PYROSCOPE_ARCH}.tar.gz" }
-          $pyroscopeUrl = $pyroscopeAsset.browser_download_url
+          Write-Output "Downloading Pyroscope ${env:PYROSCOPE_VERSION}..."
 
           $archive = Join-Path ${env:RUNNER_TEMP} "pyroscope.tar.gz"
-          Invoke-WebRequest -Uri $pyroscopeUrl -OutFile $archive
+          $pyroscopeTag = "pyroscope-${env:PYROSCOPE_VERSION}"
+          $pyroscopeAsset = "pyroscope.${env:PYROSCOPE_VERSION}-${env:PYROSCOPE_VARIANT}-${env:PYROSCOPE_ARCH}.tar.gz"
 
-          Write-Output "Extracting Pyroscope..."
+          gh release download $pyroscopeTag --pattern $pyroscopeAsset --output $archive --repo "grafana/pyroscope-dotnet"
+
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to download Pyroscope ${env:PYROSCOPE_VERSION}."
+            exit 1
+          }
+
+          Write-Output "Extracting Pyroscope archive..."
 
           $targetPath = Join-Path ${env:GITHUB_WORKSPACE} ".pyroscope"
           New-Item -Path $targetPath -Type Directory -Force | Out-Null


### PR DESCRIPTION
- Use a version of Pyroscope that matches the NuGet package.
- Use `gh release download` to acquire the profiler.
