### PR TITLE
Enable runtime async

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,7 @@
     <Authors>Martin Costello</Authors>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)API.ruleset</CodeAnalysisRuleSet>
-    <!-- HACK Workaround for https://github.com/getsentry/sentry-dotnet/issues/4801 -->
-    <ControlFlowGuard>false</ControlFlowGuard>
+    <Features>$(Features);runtime-async=on</Features>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>


### PR DESCRIPTION
- Enable runtime async to see if it's more performant.
- Remove obsolete workaround.
